### PR TITLE
Conn issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prom-client": "^15.1.2",
     "sturdy-websocket": "^0.2.1",
     "typescript": "^5.0.4",
-    "ws": "^8.13.0"
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@d8x/perpetuals-sdk": "^2.0.8-alpha",
+    "@d8x/perpetuals-sdk": "^2.1.1-alpha2",
     "dotenv": "^16.0.3",
     "ethers": "^6.13.1",
     "express": "^4.19.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@d8x/perpetuals-sdk": "^2.1.1-alpha2",
+    "@d8x/perpetuals-sdk": "^2.1.5-alpha2",
     "dotenv": "^16.0.3",
     "ethers": "^6.13.1",
     "express": "^4.19.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@d8x/perpetuals-sdk": "^2.1.5-alpha2",
+    "@d8x/perpetuals-sdk": "^2.1.6-alpha2",
     "dotenv": "^16.0.3",
     "ethers": "^6.13.1",
     "express": "^4.19.2",

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -511,7 +511,19 @@ export default class Distributor {
     let cash = position.cashCC - position.unpaidFundingCC;
     // pred mkt?
     if (this.md.isPredictionMarket(symbol)) {
-      return pmExcessBalance(pos, Sm, S3, lockedIn, cash, this.maintenanceRate.get(symbol)!) >= 0;
+      // Skip prediction markets for now
+      const excessBalance = pmExcessBalance(pos, Sm, S3, lockedIn, cash, this.maintenanceRate.get(symbol)!);
+      const isSafe = excessBalance >= 0;
+      if (!isSafe) {
+        console.log({
+          info: "Prediction market liquidation would occur, ignoring for now",
+          position,
+          excessBalance,
+          pmExcessBalanceParams: [pos, Sm, S3, lockedIn, cash, this.maintenanceRate.get(symbol)],
+        });
+      }
+      // Return true to skip prediction markets for now
+      return true;
     }
     // usual calculation
     let maintenanceMargin = ((Math.abs(pos) * Sm) / S3) * this.maintenanceRate.get(symbol)!;

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -24,7 +24,7 @@ import {
   UpdateMarkPriceMsg,
   UpdateUnitAccumulatedFundingMsg,
 } from "../types";
-import { PooledJsonRpcProvider } from "../jsonRpcPool";
+import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider";
 
 export default class Distributor {
   // objects
@@ -39,7 +39,7 @@ export default class Distributor {
    *
    * Use this.config.rpcWatch for distributor providers.
    */
-  private providers: PooledJsonRpcProvider[];
+  private providers: MultiUrlJsonRpcProvider[];
 
   // state
   private lastRefreshTime: Map<string, number> = new Map();
@@ -71,10 +71,12 @@ export default class Distributor {
 
     this.md = new MarketData(PerpetualDataHandler.readSDKConfig(config.sdkConfig));
     this.providers = [
-      new PooledJsonRpcProvider(this.config.rpcWatch, this.md.network, {
+      new MultiUrlJsonRpcProvider(this.config.rpcWatch, this.md.network, {
         timeoutSeconds: 25,
         logErrors: true,
         logRpcSwitches: true,
+        // Distributor uses free rpcs, make sure to switch on each call.
+        switchRpcOnEachRequest: true,
         staticNetwork: true,
       }),
     ];

--- a/src/executor/liquidator.ts
+++ b/src/executor/liquidator.ts
@@ -51,6 +51,8 @@ export default class Liquidator {
         logRpcSwitches: true,
         staticNetwork: true,
         maxRetries: this.config.rpcExec.length * 3,
+        // do not switch rpc on each request with premium rpcExec rpcs.
+        switchRpcOnEachRequest: false,
       }),
     ];
 
@@ -92,9 +94,8 @@ export default class Liquidator {
         // createProxyInstance attaches the given provider to the object instance
         this.bots.map((liq) => liq.api.createProxyInstance(this.providers[i]))
       );
-      success = results.every((r) => {
-        r.status === "fulfilled";
-      });
+
+      success = results.every((r) => r.status === "fulfilled");
       i = (i + 1) % this.providers.length;
       tried++;
     }

--- a/src/executor/liquidator.ts
+++ b/src/executor/liquidator.ts
@@ -4,6 +4,7 @@ import { Redis } from "ioredis";
 import { constructRedis } from "../utils";
 import { BotStatus, LiquidateTraderMsg, LiquidatorConfig } from "../types";
 import { Metrics } from "./metrics";
+import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider";
 
 // Liquidation result status
 export enum LiquidationStatus {
@@ -15,7 +16,7 @@ export enum LiquidationStatus {
 
 export default class Liquidator {
   // objects
-  private providers: PooledJsonRpcProvider[];
+  private providers: MultiUrlJsonRpcProvider[];
   private bots: { api: LiquidatorTool; busy: boolean }[];
   private redisSubClient: Redis;
 
@@ -45,7 +46,7 @@ export default class Liquidator {
     const sdkConfig = PerpetualDataHandler.readSDKConfig(this.config.sdkConfig);
 
     this.providers = [
-      new PooledJsonRpcProvider(this.config.rpcExec, new Network(sdkConfig.name || "", sdkConfig.chainId), {
+      new MultiUrlJsonRpcProvider(this.config.rpcExec, new Network(sdkConfig.name || "", sdkConfig.chainId), {
         timeoutSeconds: 25,
         logErrors: true,
         logRpcSwitches: true,

--- a/src/jsonRpcPool.ts
+++ b/src/jsonRpcPool.ts
@@ -12,8 +12,9 @@ import { executeWithTimeout } from "./utils";
 
 export interface PoolJsonRpcProviderOptions extends JsonRpcApiProviderOptions {
   // Switch to different rpc on each send call. Defaults to true. Optimal when
-  // using a lot of free rpcs.
-  switchOnEachCall?: boolean;
+  // using a lot of free rpcs. If set to false, the rpc will switch only on
+  // error.
+  switchRpcOnEachRequest?: boolean;
   // Timeout in seconds for a single send to complete. This is for entier
   // request/response duration, so make sure to use sane value. Defaults to 30
   // seconds.
@@ -49,7 +50,7 @@ export class PooledJsonRpcProvider extends JsonRpcApiProvider {
     super(network, options);
     // Setup options with sane defaults
     this.options = {
-      switchOnEachCall: true,
+      switchRpcOnEachRequest: true,
       timeoutSeconds: 30,
       maxRetries: rpcUrls.length,
       logErrors: false,
@@ -79,7 +80,7 @@ export class PooledJsonRpcProvider extends JsonRpcApiProvider {
     // Do not switch rpc if we have automatic switch enabled, since the next
     // send will automatically switch to next rpc. If we switched here, we would
     // always skip 2 rpcs.
-    if (!this.options.switchOnEachCall) {
+    if (!this.options.switchRpcOnEachRequest) {
       this.switchRpc();
     }
 
@@ -106,7 +107,7 @@ export class PooledJsonRpcProvider extends JsonRpcApiProvider {
    * @returns
    */
   async _send(payload: JsonRpcPayload | Array<JsonRpcPayload>): Promise<Array<JsonRpcResult>> {
-    if (this.options.switchOnEachCall) {
+    if (this.options.switchRpcOnEachRequest) {
       this.switchRpc();
     }
 

--- a/src/jsonRpcPool.ts
+++ b/src/jsonRpcPool.ts
@@ -1,0 +1,171 @@
+import { sleep } from "@d8x/perpetuals-sdk";
+import {
+  FetchRequest,
+  FetchResponse,
+  JsonRpcApiProvider,
+  JsonRpcApiProviderOptions,
+  JsonRpcPayload,
+  JsonRpcResult,
+  Networkish,
+} from "ethers";
+import { executeWithTimeout } from "./utils";
+
+export interface PoolJsonRpcProviderOptions extends JsonRpcApiProviderOptions {
+  // Switch to different rpc on each send call. Defaults to true. Optimal when
+  // using a lot of free rpcs.
+  switchOnEachCall?: boolean;
+  // Timeout in seconds for a single send to complete. This is for entier
+  // request/response duration, so make sure to use sane value. Defaults to 30
+  // seconds.
+  timeoutSeconds?: number;
+  // Maximum number of rpc errors until send starts throwing errors. Defaults to
+  // number of provided rpc urls.
+  maxRetries?: number;
+  // Should errors be logged to console. Defaults to false.
+  logErrors?: boolean;
+  // Whether to console.log the switch of rpc urls. Defaults to false.
+  logRpcSwitches?: boolean;
+}
+
+/**
+ * PooledJsonRpcProvider is a JsonRpcProvider that can switch between multiple RPC
+ * URLs if a request fails. Useful when using public rpcs.
+ *
+ * @see JsonRpcProvider for details
+ */
+export class PooledJsonRpcProvider extends JsonRpcApiProvider {
+  private currentConnection: FetchRequest;
+  private options: PoolJsonRpcProviderOptions;
+  private rpcUrls: string[] = [];
+  private currentRpcUrlIndex: number = 0;
+  // Resets when a request is successful
+  private currentNumberOfErrors: number = 0;
+
+  constructor(rpcUrls: string[], network?: Networkish, options?: PoolJsonRpcProviderOptions) {
+    if (rpcUrls.length <= 0) {
+      throw new Error("at least one rpc url must be provided");
+    }
+
+    super(network, options);
+    // Setup options with sane defaults
+    this.options = {
+      switchOnEachCall: true,
+      timeoutSeconds: 30,
+      maxRetries: rpcUrls.length,
+      logErrors: false,
+      logRpcSwitches: false,
+      ...options,
+    };
+    this.rpcUrls = rpcUrls;
+
+    // Initialize to the first url in the list
+    this.currentConnection = new FetchRequest(rpcUrls[0]);
+  }
+
+  _getConnection(): FetchRequest {
+    return this.currentConnection.clone();
+  }
+
+  async send(method: string, params: Array<any> | Record<string, any>): Promise<any> {
+    await this._start();
+    return await super.send(method, params);
+  }
+
+  /**
+   * Use the next rpc in list, increment errors counter and initialize new
+   * request conn.
+   */
+  switchRpcOnError() {
+    // Do not switch rpc if we have automatic switch enabled, since the next
+    // send will automatically switch to next rpc. If we switched here, we would
+    // always skip 2 rpcs.
+    if (!this.options.switchOnEachCall) {
+      this.switchRpc();
+    }
+
+    this.currentNumberOfErrors++;
+  }
+
+  /**
+   * Simply switch to the next rpc in the list.
+   */
+  private switchRpc() {
+    this.currentRpcUrlIndex = (this.currentRpcUrlIndex + 1) % this.rpcUrls.length;
+    this.currentConnection = new FetchRequest(this.getCurrentRpcUrl());
+
+    if (this.options.logRpcSwitches) {
+      console.log(`[PooledJsonRpcProvider] switched rpc from to ${this.getCurrentRpcUrl()}`);
+    }
+  }
+
+  /**
+   * Send the payload as in JsonRpcProvider, but switch rpc and retry if the
+   * request fails. If we reached the maximum number of retries, throw the last
+   * error.
+   * @param payload
+   * @returns
+   */
+  async _send(payload: JsonRpcPayload | Array<JsonRpcPayload>): Promise<Array<JsonRpcResult>> {
+    if (this.options.switchOnEachCall) {
+      this.switchRpc();
+    }
+
+    const request = this._getConnection();
+    request.body = JSON.stringify(payload);
+    request.setHeader("content-type", "application/json");
+
+    let response: FetchResponse | undefined;
+    const currentRpcUrl = this.getCurrentRpcUrl();
+    try {
+      // Timeout in ethers request is not actually treated as a real timeout for
+      // a single send, but rather more like a timeout if same request has to be
+      // sent multiple times or follow redirects... See the source of
+      // request.send(). Here we set up a real timeout for a single request to complete.
+      await executeWithTimeout(
+        (async () => {
+          response = await request.send();
+        })(),
+        this.options.timeoutSeconds! * 1000
+      );
+
+      if (response !== undefined) {
+        response.assertOk();
+      }
+    } catch (err) {
+      if (this.options.logErrors) {
+        console.error(`[PooledJsonRpcProvider@${currentRpcUrl}] request error: `, err);
+      }
+      this.switchRpcOnError();
+
+      // When max number of errors is reached - throw.
+      if (this.currentNumberOfErrors >= this.options.maxRetries!) {
+        throw err;
+      }
+
+      return this._send(payload);
+    }
+
+    let resp = response!.bodyJson;
+    if (!Array.isArray(resp)) {
+      resp = [resp];
+    }
+
+    // JSON-RPC error might be returned inside a correct response. Check for it.
+    if (resp.length > 0 && Object.hasOwnProperty.call(resp[0], "error")) {
+      if (this.options.logErrors) {
+        console.error(`[PooledJsonRpcProvider@${currentRpcUrl}] JSON-RPC response error: `, resp[0].error);
+      }
+      this.switchRpcOnError();
+      return this._send(payload);
+    }
+
+    // Request was sent successfuly, reset errors counter
+    this.currentNumberOfErrors = 0;
+
+    return resp;
+  }
+
+  getCurrentRpcUrl(): string {
+    return this.rpcUrls[this.currentRpcUrlIndex];
+  }
+}

--- a/src/multiUrlWebsocketProvider.ts
+++ b/src/multiUrlWebsocketProvider.ts
@@ -1,0 +1,256 @@
+import {
+  SocketProvider,
+  WebSocketLike,
+  WebSocketCreator,
+  Networkish,
+  JsonRpcApiProviderOptions,
+  ProviderEvent,
+  Listener,
+  JsonRpcResult,
+  JsonRpcError,
+} from "ethers";
+import { WebSocket } from "ws";
+import { MultiUrlProvider } from "./multiUrlJsonRpcProvider";
+
+export interface MultiUrlWebsocketsProviderOptions extends JsonRpcApiProviderOptions {
+  maxRetries?: number;
+  // Whether to console.log the switch of rpc urls. Defaults to false.
+  logRpcSwitches?: boolean;
+  // Whether to console.log errors. Defaults to false.
+  logErrors?: boolean;
+}
+
+/**
+ * MultiUrlWebSocketProvider is similar to traditional ethers WebsocketProvider,
+ * however it accepts multiple rpc urls and switched to next one in the list in
+ * case of failures.
+ */
+export class MultiUrlWebSocketProvider extends SocketProvider implements MultiUrlProvider {
+  // Current active ws instance
+  public websocket: WebSocket | null = null;
+  // When isStopped is true, it will not attempt to switch rpcs or create new
+  // connections. It can only be set to false by calling stop manually.
+  private isStopped = false;
+
+  private rpcUrls: string[] = [];
+  // Index of current rpc url in the list. Starts at -1 since we increment it
+  // immediately.
+  private currentRpcUrlIndex: number = -1;
+
+  // List of event listeners that were registered via this.on. We track this
+  // list to recreate any event listeners when switching to a new ws instance.
+  private registeredListeners: Array<[ProviderEvent, Listener]> = [];
+  // Number of errors encountered without a successful connection.
+  private currentErrorsNumber = 0;
+  private options: MultiUrlWebsocketsProviderOptions;
+
+  constructor(rpcUrls: string[], network?: Networkish, options?: MultiUrlWebsocketsProviderOptions) {
+    if (rpcUrls.length <= 0) {
+      throw new Error("at least one rpc url must be provided");
+    }
+    super(network, options);
+    this.rpcUrls = rpcUrls;
+    this.options = {
+      maxRetries: rpcUrls.length,
+      logRpcSwitches: false,
+      logErrors: false,
+
+      ...options,
+    };
+
+    this.startNextWebsocket();
+  }
+
+  /**
+   * (Re)starts the websocket provider with the next rpc url from provided list.
+   */
+  public async startNextWebsocket() {
+    this.isStopped = false;
+    // Close current connection if it is established, gracefully remove any
+    // event listeners and close the underlying ws conn.
+    if (this.websocket) {
+      await this._stop();
+    }
+
+    this.switchToNextRpc();
+
+    if (this.options.logRpcSwitches) {
+      console.log(
+        `[(${new Date().toISOString()}) MultiUrlWebSocketProvider] switching rpc to ${this.getCurrentRpcUrl()}`
+      );
+    }
+
+    this.startWebsocketEventListeners();
+    this.registerPreviousEventListeners();
+  }
+
+  private async startNextWebsocketIfNotStopped() {
+    if (!this.isStopped) {
+      await this.startNextWebsocket();
+    }
+  }
+
+  /**
+   * Re-registers all event listeners that were registered via this.on with
+   * previous connection
+   */
+  private registerPreviousEventListeners() {
+    this.registeredListeners.forEach(([event, listener]) => {
+      this.on(event, listener);
+    });
+  }
+
+  /**
+   * Temporarily stop the provider by closing current connection and removing
+   * listeners. startNextWebsocket must be called to resume the provider.
+   */
+  public async stop() {
+    this.isStopped = true;
+    await this._stop();
+  }
+
+  private async _stop() {
+    this.pause(true);
+    await this.removeAllListeners();
+    if (this.websocket) {
+      if (this.websocket.readyState <= WebSocket.OPEN) {
+        this.websocket.close();
+      }
+    }
+  }
+
+  /**
+   * Switch to next rpc in the list and initialize a new websocket instance.
+   */
+  private switchToNextRpc() {
+    this.currentRpcUrlIndex = (this.currentRpcUrlIndex + 1) % this.rpcUrls.length;
+    this.websocket = this.newWsInstance();
+  }
+
+  /**
+   * Start WebSocket connection listeners. Websocket instance must be set.
+   */
+  private startWebsocketEventListeners() {
+    // This should never happen
+    if (this.websocket === null) {
+      throw Error("websocket is not initialized");
+    }
+
+    // Copy from ethers.WebSocketProvider
+    this.websocket.onopen = async () => {
+      try {
+        await this._start();
+        this.resume();
+      } catch (error) {
+        console.log("failed to start WebsocketProvider", error);
+      }
+
+      this.currentErrorsNumber = 0;
+    };
+
+    this.websocket.onerror = (data) => {
+      const { error } = data;
+      this.emit("error", error);
+      // Connection failure, attempt to switch to next rpc url
+      // console.log("got websocket error", error, this.websocket.readyState);
+      if (this.options.logErrors) {
+        console.log(
+          `[(${new Date().toISOString()}) MultiUrlWebSocketProvider@${this.getCurrentRpcUrl()}] Connection error:`,
+          error
+        );
+      }
+      if (this.currentErrorsNumber >= this.options.maxRetries!) {
+        console.error(`[(${new Date().toISOString()}) MultiUrlWebSocketProvider] Max retries reached`);
+        throw error;
+      }
+      this.currentErrorsNumber++;
+      this.startNextWebsocketIfNotStopped();
+    };
+
+    this.websocket.onclose = (closeEvent) => {
+      // @TODO handle potential closes. One caveat is that we close the old
+      // websocket connection on switch, so if we just blindly switched here, we
+      // might introduce an infinite loop of switching websocket conns.
+    };
+
+    this.websocket.onmessage = (message) => {
+      const data: string = message.data as string;
+      // Check if message does not contain errors
+      try {
+        const result = <JsonRpcResult | JsonRpcError>JSON.parse(data);
+        if ("error" in result) {
+          console.log(
+            `[(${new Date().toISOString()}) MultiUrlWebSocketProvider@${this.getCurrentRpcUrl()}] Received error in message:`,
+            result.error
+          );
+          this.startNextWebsocketIfNotStopped();
+          return;
+        }
+      } catch (e) {
+        if (this.options.logErrors) {
+          console.log(
+            `[(${new Date().toISOString()}) MultiUrlWebSocketProvider@${this.getCurrentRpcUrl()}] Invalid JSON in message:`,
+            data
+          );
+          this.startNextWebsocketIfNotStopped();
+        }
+        return;
+      }
+
+      // Reset error counter on successful message
+      this.currentErrorsNumber = 0;
+      this._processMessage(data);
+    };
+  }
+
+  /**
+   * @returns new Websocket instance with current rpc url.
+   */
+  private newWsInstance(): WebSocket {
+    return new WebSocket(this.getCurrentRpcUrl());
+  }
+
+  async _write(message: string): Promise<void> {
+    this.websocket!.send(message);
+  }
+
+  /**
+   * Destroy the provider and close underlying connection. This will render
+   * provider unusable and will require to create a new instance.
+   */
+  public async destroy(): Promise<void> {
+    if (this.websocket !== null) {
+      if (this.websocket.readyState <= WebSocket.OPEN) {
+        this.websocket.close();
+      }
+      this.websocket = null;
+    }
+    super.destroy();
+  }
+
+  /**
+   * @returns the current rpc url
+   */
+  public getCurrentRpcUrl(): string {
+    return this.rpcUrls[this.currentRpcUrlIndex];
+  }
+
+  /**
+   * Base class on override which tracks event listeners whenever we need to
+   * create a new ws connection instance.
+   * @param event
+   * @param listener
+   * @returns
+   */
+  public async on(event: ProviderEvent, listener: Listener) {
+    this.registeredListeners.push([event, listener]);
+    return super.on(event, listener);
+  }
+
+  /**
+   * Reset the number of errors back to 0.
+   */
+  public resetErrorNumber() {
+    this.currentErrorsNumber = 0;
+  }
+}

--- a/src/sentinel/blockchainListener.ts
+++ b/src/sentinel/blockchainListener.ts
@@ -5,7 +5,9 @@ import Websocket from "ws";
 import { LiquidateMsg, LiquidatorConfig, UpdateMarginAccountMsg, UpdateMarkPriceMsg } from "../types";
 import { constructRedis, executeWithTimeout, sleep } from "../utils";
 
-import { JsonRpcProvider, Network, WebSocketProvider } from "ethers";
+import { JsonRpcProvider, Network, SocketProvider, WebSocketProvider } from "ethers";
+import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider";
+import { MultiUrlWebSocketProvider } from "../multiUrlWebsocketProvider";
 
 enum ListeningMode {
   Polling = "Polling",
@@ -17,9 +19,12 @@ export default class BlockhainListener {
   // Network is initialized in start() method
   private network!: Network;
 
-  // objects
-  private httpProvider: JsonRpcProvider;
-  private listeningProvider: JsonRpcProvider | WebSocketProvider | undefined;
+  // Single instance of multiurl http provider.
+  private httpProvider: MultiUrlJsonRpcProvider;
+  // Single instance of multiurl ws provider. When switching listener, we will
+  // simply switch to next rpc url in the list.
+  private multiUrlWsProvider!: MultiUrlWebSocketProvider;
+  private listeningProvider: MultiUrlJsonRpcProvider | MultiUrlWebSocketProvider | undefined;
   private redisPubClient: Redis;
   private md: MarketData;
 
@@ -31,24 +36,31 @@ export default class BlockhainListener {
   private switchingRPC = false;
 
   constructor(config: LiquidatorConfig) {
+    if (config.rpcListenHttp.length <= 0) {
+      throw new Error("Please specify at least one HTTP RPC URL in rpcListenHttp configuration field");
+    }
+
     this.config = config;
     this.md = new MarketData(PerpetualDataHandler.readSDKConfig(this.config.sdkConfig));
     this.redisPubClient = constructRedis("sentinelPubClient");
-    this.httpProvider = new JsonRpcProvider(this.chooseHttpRpc(), this.md.network, { staticNetwork: true });
+    this.httpProvider = new MultiUrlJsonRpcProvider(this.config.rpcListenHttp, this.md.network, {
+      logErrors: false,
+      logRpcSwitches: true,
+      switchRpcOnEachRequest: true,
+      timeoutSeconds: 20,
+      maxRetries: this.config.rpcListenHttp.length * 5,
+
+      staticNetwork: true,
+      polling: true,
+    });
+    this.multiUrlWsProvider = new MultiUrlWebSocketProvider(this.config.rpcListenWs, this.network, {
+      logErrors: true,
+      logRpcSwitches: true,
+      maxRetries: this.config.rpcListenWs.length * 4,
+
+      staticNetwork: true,
+    });
     this.lastBlockReceivedAt = Date.now();
-  }
-
-  private chooseHttpRpc() {
-    const idx = (this.lastRpcIndex.http + 1) % this.config.rpcListenHttp.length;
-    this.lastRpcIndex.http = idx;
-    console.log(idx, this.config.rpcListenHttp[idx]);
-    return this.config.rpcListenHttp[idx];
-  }
-
-  private chooseWsRpc() {
-    const idx = (this.lastRpcIndex.ws + 1) % this.config.rpcListenWs.length;
-    this.lastRpcIndex.ws = idx;
-    return this.config.rpcListenWs[idx];
   }
 
   public unsubscribe() {
@@ -61,16 +73,18 @@ export default class BlockhainListener {
   public checkHeartbeat() {
     const blockTime = Math.floor((Date.now() - this.lastBlockReceivedAt) / 1_000);
     if (blockTime > this.config.waitForBlockSeconds) {
-      console.log(
-        `${new Date(Date.now()).toISOString()}: websocket connection block time is ${blockTime} - disconnecting`
-      );
+      console.log({
+        info: "Last block received too long ago - heartbeat check failed",
+        receivedSecondsAgo: blockTime,
+        time: new Date(Date.now()).toISOString(),
+      });
       return false;
     }
-    console.log(
-      `${new Date(Date.now()).toISOString()}: websocket connection block time is ${blockTime} seconds @ block ${
-        this.blockNumber
-      }`
-    );
+    console.log({
+      info: "Last block received within expected time",
+      receivedSecondsAgo: blockTime,
+      time: new Date(Date.now()).toISOString(),
+    });
     return true;
   }
 
@@ -83,50 +97,46 @@ export default class BlockhainListener {
     this.blockNumber = undefined;
     this.switchingRPC = true;
 
-    // Destroy websockets provider and close underlying connection. Do not call
-    // unsubscribe for websocket provider as it will cause async eth_unsubscribe
-    // calls while underlying connection is being closed.
-    //
-    // Change this once ether.js is upgraded to v6
-    if (this.listeningProvider instanceof WebSocketProvider) {
-      this.listeningProvider.destroy();
-    } else {
-      this.listeningProvider?.removeAllListeners();
+    // Remove existing listeners. MultiUrlWebSocketProvider handles this
+    // internally, so this is only for Http providers.
+    if (this.listeningProvider) {
+      if (this.listeningProvider instanceof MultiUrlWebSocketProvider) {
+        await this.listeningProvider.stop();
+      }
+      await this.listeningProvider.removeAllListeners();
     }
 
     if (this.mode == ListeningMode.Events || this.config.rpcListenWs.length < 1) {
-      const url = this.chooseHttpRpc();
       console.log({
-        info: "Switching from WS to HTTP",
-        newRpc: url,
+        info: "Switching from Websocket to HTTP provider",
         time: new Date(Date.now()).toISOString(),
       });
       this.mode = ListeningMode.Polling;
-      this.listeningProvider = new JsonRpcProvider(url, this.network, {
-        staticNetwork: true,
-        polling: true,
-      });
+      this.listeningProvider = this.httpProvider;
     } else if (this.config.rpcListenWs.length > 0) {
-      const url = this.chooseWsRpc();
       console.log({
         info: "Switching from HTTP to WS",
-        newRpc: url,
+        nexRpcUrl: this.multiUrlWsProvider.getCurrentRpcUrl(),
         time: new Date(Date.now()).toISOString(),
       });
-
       this.mode = ListeningMode.Events;
-      this.listeningProvider = new WebSocketProvider(url, this.network, {
-        staticNetwork: true,
-      });
+      // startNextWebsocket will be called in health checks, therefore we don't
+      // need to do that here.
+      this.listeningProvider = this.multiUrlWsProvider;
     }
     this.switchingRPC = false;
+
+    this.listeningProvider!.resetErrorNumber();
 
     await this.addListeners();
     this.redisPubClient.publish("switch-mode", this.mode);
   }
 
-  private async connectOrSwitch() {
-    // try to connect via ws, switch to http on failure
+  /**
+   * Wait for blockNumber to come from WS connection or switch to http on
+   * failure.
+   */
+  private async connectWsOrSwitchToHttp() {
     this.blockNumber = undefined;
     setTimeout(async () => {
       if (!this.blockNumber) {
@@ -141,31 +151,28 @@ export default class BlockhainListener {
     // periodic health checks
     setInterval(async () => {
       if (this.mode == ListeningMode.Events) {
-        // currently on WS - check that block time is still reasonable or if we need to switch
+        // currently on WS - check that block time is still reasonable or if we
+        // need to switch
         if (!this.checkHeartbeat()) {
           this.switchListeningMode();
         }
       } else if (this.config.rpcListenWs.length > 0) {
-        // currently on HTTP - check if we can switch to WS by seeing if we get blocks
+        // currently on HTTP - check if we can switch to WS by seeing if we get
+        // blocks with next WS connection.
         let success = false;
-        let wsProvider = new WebSocketProvider(
-          new SturdyWebSocket(this.chooseWsRpc(), {
-            wsConstructor: Websocket,
-          }),
-          this.network
-        );
-        wsProvider.once("block", () => {
+        console.log(`[${new Date(Date.now()).toISOString()}] attempting to switch to WS`);
+        await this.multiUrlWsProvider.startNextWebsocket();
+        this.multiUrlWsProvider.once("block", () => {
           success = true;
         });
         // after N seconds, check if we received a block - if yes, switch
         setTimeout(async () => {
           if (success) {
             await this.switchListeningMode();
+          } else {
+            // Otherwise just stop the multi url ws provider and try again later
+            await this.multiUrlWsProvider.stop();
           }
-
-          // Destroy the one-off websocket provider and close underlying ws
-          // connection.
-          wsProvider.destroy();
         }, this.config.waitForBlockSeconds * 1_000);
       }
     }, this.config.healthCheckSeconds * 1_000);
@@ -186,58 +193,34 @@ export default class BlockhainListener {
   }
 
   public async start() {
-    // Catch exceptions from failed async calls (mainly from within event
-    // listeners) within ethers providers. Ethers seem to sends async requests
-    // which cannot be caught by try/catch. This global handler checks if
-    // uncaught error originates from ethers by inspecting known error messages
-    // and attempts to switch listener.
-    process.on("uncaughtException", (error) => {
-      if (error instanceof Error) {
-        if (this.containsEthersConnErrors(error.message)) {
-          console.log({
-            info: "Uncaught ethers exception with RPC server error",
-            time: new Date(Date.now()).toISOString(),
-            message: error.message,
-          });
-          this.switchListeningMode();
-        } else {
-          console.log(error);
-          process.exit(1);
-        }
-      }
-    });
-
-    // http rpc
     this.network = await executeWithTimeout(
       this.httpProvider.getNetwork(),
-      10_000,
+      // Use at least 2X timeout of HTTP provider in case some of the rpc are
+      // slow to respond.
+      40_000,
       "could not establish http connection"
     );
+
     await this.md.createProxyInstance(this.httpProvider);
-    console.log(
-      `${new Date(Date.now()).toISOString()}: connected to ${this.network.name}, chain id ${
-        this.network.chainId
-      }, using HTTP provider`
-    );
-    // ws rpc
+
     if (this.config.rpcListenWs.length > 0) {
-      this.listeningProvider = new WebSocketProvider(
-        new SturdyWebSocket(this.chooseWsRpc(), {
-          wsConstructor: Websocket,
-        }),
-        this.network,
-        { staticNetwork: true }
-      );
+      this.listeningProvider = this.multiUrlWsProvider;
     } else if (this.config.rpcListenHttp.length > 0) {
-      this.listeningProvider = new JsonRpcProvider(this.chooseHttpRpc(), this.network, {
-        staticNetwork: true,
-        polling: true,
-      });
+      this.listeningProvider = this.httpProvider;
     } else {
       throw new Error("Please specify RPC URLs for listening to blockchain events");
     }
+    console.log({
+      info: "BlockchainListener started",
+      time: new Date(Date.now()).toISOString(),
+      network: {
+        name: this.network.name,
+        chainId: this.network.chainId,
+      },
+      listenerType: this.listeningProvider instanceof MultiUrlWebSocketProvider ? "Websocket" : "Http",
+    });
 
-    this.connectOrSwitch();
+    this.connectWsOrSwitchToHttp();
     this.addListeners();
     this.resetHealthChecks();
   }
@@ -246,6 +229,7 @@ export default class BlockhainListener {
     if (this.listeningProvider === undefined) {
       throw new Error("No provider ready to listen.");
     }
+
     // on error terminate
     this.listeningProvider.on("error", (e) => {
       console.log(

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,10 +14,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@d8x/perpetuals-sdk@^2.1.5-alpha2":
-  version "2.1.5-alpha2"
-  resolved "https://registry.yarnpkg.com/@d8x/perpetuals-sdk/-/perpetuals-sdk-2.1.5-alpha2.tgz#3bfb2c7e46236f8b42e7d0a55dce0502b6d6590c"
-  integrity sha512-mNMKliBN8zBKUf1Sr5anvWUZ2IxlhPALaeIkvJ63SLPAlfLWuS86QvOnqPJH1QCQTHBJ/CkuLDIEkFZdnWG6fQ==
+"@d8x/perpetuals-sdk@^2.1.6-alpha2":
+  version "2.1.6-alpha2"
+  resolved "https://registry.yarnpkg.com/@d8x/perpetuals-sdk/-/perpetuals-sdk-2.1.6-alpha2.tgz#be554f7f8976f29aa07f1556760fdf80f504baac"
+  integrity sha512-Smoemmo1JsWuEA4w0TjJuBrhxfGtn4+K8rkbB3K2WoFgtlKORFRgFIU3cqvEVTNHa88kzmcwJDer1gvQV1S41w==
   dependencies:
     "@typechain/ethers-v6" "^0.5.1"
     buffer "6.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1420,10 +1420,10 @@ ws@8.17.1:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
   integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
-ws@^8.13.0:
-  version "8.14.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.14.2.tgz#6c249a806eb2db7a20d26d51e7709eab7b2e6c7f"
-  integrity sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==
+ws@^8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
 yallist@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,10 +14,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@d8x/perpetuals-sdk@^2.1.1-alpha2":
-  version "2.1.1-alpha2"
-  resolved "https://registry.yarnpkg.com/@d8x/perpetuals-sdk/-/perpetuals-sdk-2.1.1-alpha2.tgz#eb0dd2b51361a9990192d8ae064d4c08810362ad"
-  integrity sha512-nZuauZTTPW2hSZuOJ2+j63ByHdhrqdC9D/24ahsBvaT7wLhSR8/hfya3wcptAjIJRAS1ebf5IjR+oFkJ2BP6hg==
+"@d8x/perpetuals-sdk@^2.1.5-alpha2":
+  version "2.1.5-alpha2"
+  resolved "https://registry.yarnpkg.com/@d8x/perpetuals-sdk/-/perpetuals-sdk-2.1.5-alpha2.tgz#3bfb2c7e46236f8b42e7d0a55dce0502b6d6590c"
+  integrity sha512-mNMKliBN8zBKUf1Sr5anvWUZ2IxlhPALaeIkvJ63SLPAlfLWuS86QvOnqPJH1QCQTHBJ/CkuLDIEkFZdnWG6fQ==
   dependencies:
     "@typechain/ethers-v6" "^0.5.1"
     buffer "6.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,10 +14,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@d8x/perpetuals-sdk@^2.0.8-alpha":
-  version "2.0.8-alpha"
-  resolved "https://registry.yarnpkg.com/@d8x/perpetuals-sdk/-/perpetuals-sdk-2.0.8-alpha.tgz#7290a0c497b4b8d43331d9cb076255f67187872f"
-  integrity sha512-btJ1QSOWFednsjdobCjMS7b3BLpNDa5fC3X9K1oOkAsbtR7S5lulqmYLqKeoirE4OeE1ELa4xzUaJ+XocM3oCQ==
+"@d8x/perpetuals-sdk@^2.1.1-alpha2":
+  version "2.1.1-alpha2"
+  resolved "https://registry.yarnpkg.com/@d8x/perpetuals-sdk/-/perpetuals-sdk-2.1.1-alpha2.tgz#eb0dd2b51361a9990192d8ae064d4c08810362ad"
+  integrity sha512-nZuauZTTPW2hSZuOJ2+j63ByHdhrqdC9D/24ahsBvaT7wLhSR8/hfya3wcptAjIJRAS1ebf5IjR+oFkJ2BP6hg==
   dependencies:
     "@typechain/ethers-v6" "^0.5.1"
     buffer "6.0.3"
@@ -294,24 +294,6 @@ body-parser@1.20.2:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
-body-parser@1.20.2:
-  version "1.20.2"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.2.tgz#6feb0e21c4724d06de7ff38da36dad4f57a747fd"
-  integrity sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==
-  dependencies:
-    bytes "3.1.2"
-    content-type "~1.0.5"
-    debug "2.6.9"
-    depd "2.0.0"
-    destroy "1.2.0"
-    http-errors "2.0.0"
-    iconv-lite "0.4.24"
-    on-finished "2.4.1"
-    qs "6.11.0"
-    raw-body "2.5.2"
-    type-is "~1.6.18"
-    unpipe "1.0.0"
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -543,28 +525,6 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
-encodeurl@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
-  integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
-
-es-define-property@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.0.tgz#c7faefbdff8b2696cf5f46921edfb77cc4ba3845"
-  integrity sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==
-  dependencies:
-    get-intrinsic "^1.2.4"
-
-es-errors@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
-  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
-
-escape-html@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
-  integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
-
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -587,43 +547,6 @@ ethers@^6.13.1:
     aes-js "4.0.0-beta.5"
     tslib "2.4.0"
     ws "8.17.1"
-
-express@^4.19.2:
-  version "4.19.2"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.19.2.tgz#e25437827a3aa7f2a827bc8171bbbb664a356465"
-  integrity sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==
-  dependencies:
-    accepts "~1.3.8"
-    array-flatten "1.1.1"
-    body-parser "1.20.2"
-    content-disposition "0.5.4"
-    content-type "~1.0.4"
-    cookie "0.6.0"
-    cookie-signature "1.0.6"
-    debug "2.6.9"
-    depd "2.0.0"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    finalhandler "1.2.0"
-    fresh "0.5.2"
-    http-errors "2.0.0"
-    merge-descriptors "1.0.1"
-    methods "~1.1.2"
-    on-finished "2.4.1"
-    parseurl "~1.3.3"
-    path-to-regexp "0.1.7"
-    proxy-addr "~2.0.7"
-    qs "6.11.0"
-    range-parser "~1.2.1"
-    safe-buffer "5.2.1"
-    send "0.18.0"
-    serve-static "1.15.0"
-    setprototypeof "1.2.0"
-    statuses "2.0.1"
-    type-is "~1.6.18"
-    utils-merge "1.0.1"
-    vary "~1.1.2"
 
 express@^4.19.2:
   version "4.19.2"
@@ -815,24 +738,6 @@ hasown@^2.0.0:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
-
-http-errors@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
-  integrity sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==
-  dependencies:
-    depd "2.0.0"
-    inherits "2.0.4"
-    setprototypeof "1.2.0"
-    statuses "2.0.1"
-    toidentifier "1.0.1"
-
-iconv-lite@0.4.24:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
-  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
 
 http-errors@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Public RPCs seem to be highly limited (arbitrum's case) and causes various errors within ethers providers which produce uncaught exceptions which crash the service. 

This PR introduces multi url http and wss providers which accept multiple rpc endpoints and switches to next one if connection errors out or error responses are returned.

Note, this PR is rebased on `pred-mkt` branch and includes changes for new px structure and bumps sdk to use version with prediction markets.

Note 2, this PR temporarily switches prediction market liquidations off.