### PR TITLE
Fix/use new sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@d8-x/d8x-node-sdk": "0.1.58",
+    "@d8-x/d8x-node-sdk": "0.1.66",
     "dotenv": "^16.0.3",
     "ethers": "^6.13.1",
     "express": "^4.19.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@d8-x/d8x-node-sdk": "0.1.66",
+    "@d8-x/d8x-node-sdk": "0.1.67",
     "dotenv": "^16.0.3",
     "ethers": "^6.13.1",
     "express": "^4.19.2",

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -116,7 +116,7 @@ export default class Distributor {
       .map((pool) =>
         pool.perpetuals
           .filter(({ state }) => state === "NORMAL")
-          .map((perpetual) => `${perpetual.baseCurrency}-${perpetual.quoteCurrency}-${pool.poolSymbol}`),
+          .map((perpetual) => `${perpetual.baseCurrency}-${perpetual.quoteCurrency}-${pool.poolSymbol}`)
       )
       .flat();
 
@@ -124,11 +124,11 @@ export default class Distributor {
       // static info
       this.maintenanceRate.set(
         symbol,
-        PerpetualDataHandler.getMaintenanceMarginRate(this.md.getPerpetualStaticInfo(symbol)),
+        PerpetualDataHandler.getMaintenanceMarginRate(this.md.getPerpetualStaticInfo(symbol))
       );
       this.isQuote.set(
         symbol,
-        this.md.getPerpetualStaticInfo(symbol).collateralCurrencyType == COLLATERAL_CURRENCY_QUOTE,
+        this.md.getPerpetualStaticInfo(symbol).collateralCurrencyType == COLLATERAL_CURRENCY_QUOTE
       );
       // price info
       try {

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -26,6 +26,7 @@ import {
   UpdateUnitAccumulatedFundingMsg,
 } from "../types.js";
 import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
+import { publishSDKState } from "../sdkState.js";
 
 export default class Distributor {
   // objects
@@ -101,6 +102,12 @@ export default class Distributor {
     }
     if (!success) {
       console.log(`${new Date(Date.now()).toISOString()}: all rpcs are down ${this.config.rpcWatch.join(", ")}`);
+    }
+
+    try {
+      await publishSDKState(this.redisPubClient, this.chainId, this.md.exportState());
+    } catch (e) {
+      console.log(`${new Date(Date.now()).toISOString()}: failed to publish SDK state: ${e}`);
     }
 
     const info = await this.md.exchangeInfo();

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -26,7 +26,7 @@ import {
   UpdateUnitAccumulatedFundingMsg,
 } from "../types.js";
 import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
-import { SDK_STATE_REPUBLISH_SECONDS, publishSDKState } from "../sdkState.js";
+import { SDK_STATE_REPUBLISH_SECONDS, publishSDKState, refreshSDKStateTTL } from "../sdkState.js";
 
 export default class Distributor {
   // objects
@@ -177,9 +177,18 @@ export default class Distributor {
     this.ready = true;
   }
 
+  private lastPublishedState: string | undefined;
+
   private async publishState(): Promise<void> {
     try {
-      await publishSDKState(this.redisPubClient, this.chainId, this.md.exportState());
+      const state = this.md.exportState();
+      const serialized = JSON.stringify(state);
+      if (serialized === this.lastPublishedState) {
+        await refreshSDKStateTTL(this.redisPubClient, this.chainId);
+        return;
+      }
+      await publishSDKState(this.redisPubClient, this.chainId, state);
+      this.lastPublishedState = serialized;
     } catch (e) {
       console.log(`${new Date(Date.now()).toISOString()}: failed to publish SDK state: ${e}`);
     }

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -106,11 +106,10 @@ export default class Distributor {
         `commander: all RPCs are down (${this.config.rpcWatch.join(", ")})`
       );
     }
-
+    
+    const info = await this.md.exchangeInfo();
     await this.publishState();
     setInterval(() => void this.publishState(), SDK_STATE_REPUBLISH_SECONDS * 1000).unref();
-
-    const info = await this.md.exchangeInfo();
 
     this.symbols = info.pools
       .filter(({ isRunning }) => isRunning)

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -106,7 +106,7 @@ export default class Distributor {
 
     if (success) {
       await this.publishState();
-      setInterval(() => void this.publishState(), SDK_STATE_REPUBLISH_SECONDS * 1000);
+      setInterval(() => void this.publishState(), SDK_STATE_REPUBLISH_SECONDS * 1000).unref();
     }
 
     const info = await this.md.exchangeInfo();

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -314,11 +314,7 @@ export default class Distributor {
     const pxSubmission = this.pxSubmission.get(symbol)!;
     const account = await this.md
       .getReadOnlyProxyInstance()
-      .getTraderState(perpetualId, address, [
-        floatToABK64x64(pxSubmission.s2),
-        floatToABK64x64(pxSubmission.s3 ?? 0),
-        floatToABK64x64(pxSubmission.rho ?? 0),
-      ]);
+      .getTraderState(perpetualId, address, [floatToABK64x64(pxSubmission.s2), floatToABK64x64(pxSubmission.s3 ?? 0), floatToABK64x64(pxSubmission.rho ?? 0)]);
 
     const position: Position = {
       perpetualId: perpetualId,
@@ -410,11 +406,7 @@ export default class Distributor {
         callData: proxy.interface.encodeFunctionData("getTraderState", [
           perpId,
           addr,
-          [
-            floatToABK64x64(pxSubmission.s2),
-            floatToABK64x64(pxSubmission.s3 ?? 0),
-            floatToABK64x64(pxSubmission.rho ?? 0),
-          ],
+          [floatToABK64x64(pxSubmission.s2), floatToABK64x64(pxSubmission.s3 ?? 0), floatToABK64x64(pxSubmission.rho ?? 0)],
         ]),
       }));
       promises2.push(multicall.connect(rpcProviders[providerIdx]).aggregate3.staticCall(calls));
@@ -435,7 +427,7 @@ export default class Distributor {
               if (result.success) {
                 const account = proxy.interface.decodeFunctionResult(
                   "getTraderState",
-                  result.returnData,
+                  result.returnData
                 )[0] as BigNumberish[];
                 /**
                  * 0 marginBalance : number; // current margin balance

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -92,10 +92,11 @@ export default class Distributor {
    * If none of the RPCs work, it sleeps before crashing.
    */
   public async initialize() {
-    // Create a proxy instance to access the blockchain
+    // RPC URL randomization happens at config load time using the `shuffle()` in
+    // utils.loadConfig, `this.config.rpcWatch` is already a shuffled list by
+    // the time it reaches the MultiUrlJsonRpcProvider constructor
     let success = false;
     let i = 0;
-    this.providers = this.providers.sort(() => Math.random() - 0.5);
     while (!success && i < this.providers.length) {
       const results = (await Promise.allSettled([this.md.createProxyInstance(this.providers[i])]))[0];
       success = results.status === "fulfilled";

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -52,6 +52,7 @@ export default class Distributor {
   private unitAccumulatedFunding: Map<string, number> = new Map();
   private messageSentAt: Map<string, number> = new Map();
   private pricesFetchedAt: Map<string, number> = new Map();
+  private lastPublishedState: string | undefined;
   public ready: boolean = false;
 
   // static info
@@ -176,8 +177,6 @@ export default class Distributor {
 
     this.ready = true;
   }
-
-  private lastPublishedState: string | undefined;
 
   private async publishState(): Promise<void> {
     try {

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -26,7 +26,7 @@ import {
   UpdateUnitAccumulatedFundingMsg,
 } from "../types.js";
 import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
-import { publishSDKState } from "../sdkState.js";
+import { SDK_STATE_REPUBLISH_SECONDS, publishSDKState } from "../sdkState.js";
 
 export default class Distributor {
   // objects
@@ -104,10 +104,9 @@ export default class Distributor {
       console.log(`${new Date(Date.now()).toISOString()}: all rpcs are down ${this.config.rpcWatch.join(", ")}`);
     }
 
-    try {
-      await publishSDKState(this.redisPubClient, this.chainId, this.md.exportState());
-    } catch (e) {
-      console.log(`${new Date(Date.now()).toISOString()}: failed to publish SDK state: ${e}`);
+    if (success) {
+      await this.publishState();
+      setInterval(() => void this.publishState(), SDK_STATE_REPUBLISH_SECONDS * 1000);
     }
 
     const info = await this.md.exchangeInfo();
@@ -176,6 +175,14 @@ export default class Distributor {
     );
 
     this.ready = true;
+  }
+
+  private async publishState(): Promise<void> {
+    try {
+      await publishSDKState(this.redisPubClient, this.chainId, this.md.exportState());
+    } catch (e) {
+      console.log(`${new Date(Date.now()).toISOString()}: failed to publish SDK state: ${e}`);
+    }
   }
 
   private requireReady() {

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -15,7 +15,7 @@ import {
 } from "@d8-x/d8x-node-sdk";
 import { BigNumberish } from "ethers";
 import { Redis } from "ioredis";
-import { constructRedis } from "../utils.js";
+import { constructRedis, stableStringify } from "../utils.js";
 import {
   LiquidateMsg,
   LiquidateTraderMsg,
@@ -182,10 +182,10 @@ export default class Distributor {
   private async publishState(): Promise<void> {
     try {
       const state = this.md.exportState();
-      const serialized = JSON.stringify(state);
+      const serialized = stableStringify(state);
       if (serialized === this.lastPublishedState) {
-        await refreshSDKStateTTL(this.redisPubClient, this.chainId);
-        return;
+        const refreshed = await refreshSDKStateTTL(this.redisPubClient, this.chainId);
+        if (refreshed) return;
       }
       await publishSDKState(this.redisPubClient, this.chainId, state);
       this.lastPublishedState = serialized;

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -101,13 +101,13 @@ export default class Distributor {
       i++;
     }
     if (!success) {
-      console.log(`${new Date(Date.now()).toISOString()}: all rpcs are down ${this.config.rpcWatch.join(", ")}`);
+      throw new Error(
+        `commander: all RPCs are down (${this.config.rpcWatch.join(", ")})`
+      );
     }
 
-    if (success) {
-      await this.publishState();
-      setInterval(() => void this.publishState(), SDK_STATE_REPUBLISH_SECONDS * 1000).unref();
-    }
+    await this.publishState();
+    setInterval(() => void this.publishState(), SDK_STATE_REPUBLISH_SECONDS * 1000).unref();
 
     const info = await this.md.exchangeInfo();
 

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -190,7 +190,11 @@ export default class Distributor {
       await publishSDKState(this.redisPubClient, this.chainId, state);
       this.lastPublishedState = serialized;
     } catch (e) {
-      console.log(`${new Date(Date.now()).toISOString()}: failed to publish SDK state: ${e}`);
+      console.log(
+        `${new Date(Date.now()).toISOString()}: failed to publish SDK state: ${
+          e instanceof Error ? e.stack ?? e.message : String(e)
+        }`
+      );
     }
   }
 

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -116,7 +116,7 @@ export default class Distributor {
       .map((pool) =>
         pool.perpetuals
           .filter(({ state }) => state === "NORMAL")
-          .map((perpetual) => `${perpetual.baseCurrency}-${perpetual.quoteCurrency}-${pool.poolSymbol}`)
+          .map((perpetual) => `${perpetual.baseCurrency}-${perpetual.quoteCurrency}-${pool.poolSymbol}`),
       )
       .flat();
 
@@ -124,11 +124,11 @@ export default class Distributor {
       // static info
       this.maintenanceRate.set(
         symbol,
-        PerpetualDataHandler.getMaintenanceMarginRate(this.md.getPerpetualStaticInfo(symbol))
+        PerpetualDataHandler.getMaintenanceMarginRate(this.md.getPerpetualStaticInfo(symbol)),
       );
       this.isQuote.set(
         symbol,
-        this.md.getPerpetualStaticInfo(symbol).collateralCurrencyType == COLLATERAL_CURRENCY_QUOTE
+        this.md.getPerpetualStaticInfo(symbol).collateralCurrencyType == COLLATERAL_CURRENCY_QUOTE,
       );
       // price info
       try {
@@ -171,7 +171,7 @@ export default class Distributor {
           console.log(`${new Date(Date.now()).toISOString()}: redis subscription failed: ${err}`);
           process.exit(1);
         }
-      }
+      },
     );
 
     this.ready = true;
@@ -239,7 +239,7 @@ export default class Distributor {
             sleepForSec(5).then(() =>
               this.fetchPosition(account.perpetualId, account.traderAddr).then((pos) => {
                 this.updatePosition(pos).then();
-              })
+              }),
             );
             break;
           }
@@ -303,7 +303,11 @@ export default class Distributor {
     const pxSubmission = this.pxSubmission.get(symbol)!;
     const account = await this.md
       .getReadOnlyProxyInstance()
-      .getTraderState(perpetualId, address, [floatToABK64x64(pxSubmission.s2), floatToABK64x64(pxSubmission.s3 ?? 0), floatToABK64x64(pxSubmission.rho ?? 0)]);
+      .getTraderState(perpetualId, address, [
+        floatToABK64x64(pxSubmission.s2),
+        floatToABK64x64(pxSubmission.s3 ?? 0),
+        floatToABK64x64(pxSubmission.rho ?? 0),
+      ]);
 
     const position: Position = {
       perpetualId: perpetualId,
@@ -395,7 +399,11 @@ export default class Distributor {
         callData: proxy.interface.encodeFunctionData("getTraderState", [
           perpId,
           addr,
-          [floatToABK64x64(pxSubmission.s2), floatToABK64x64(pxSubmission.s3 ?? 0), floatToABK64x64(pxSubmission.rho ?? 0)],
+          [
+            floatToABK64x64(pxSubmission.s2),
+            floatToABK64x64(pxSubmission.s3 ?? 0),
+            floatToABK64x64(pxSubmission.rho ?? 0),
+          ],
         ]),
       }));
       promises2.push(multicall.connect(rpcProviders[providerIdx]).aggregate3.staticCall(calls));
@@ -416,7 +424,7 @@ export default class Distributor {
               if (result.success) {
                 const account = proxy.interface.decodeFunctionResult(
                   "getTraderState",
-                  result.returnData
+                  result.returnData,
                 )[0] as BigNumberish[];
                 /**
                  * 0 marginBalance : number; // current margin balance

--- a/src/commander/main.ts
+++ b/src/commander/main.ts
@@ -13,4 +13,9 @@ async function start() {
   obj.run();
 }
 
-start();
+start().catch((err) => {
+  console.error(
+    `${new Date().toISOString()}: commander fatal: ${err instanceof Error ? err.stack ?? err.message : String(err)}`
+  );
+  process.exit(1);
+});

--- a/src/commander/main.ts
+++ b/src/commander/main.ts
@@ -10,7 +10,7 @@ async function start() {
   const cfg = await loadConfig(sdkConfig);
   const obj = new Distributor(cfg);
   await obj.initialize();
-  obj.run();
+  await obj.run();
 }
 
 start().catch((err) => {

--- a/src/executor/liquidator.ts
+++ b/src/executor/liquidator.ts
@@ -106,13 +106,12 @@ export default class Liquidator {
     const { usedCache, providerIndex, cacheAgeMs } = await initMarketDataWithCache(
       md,
       this.providers,
-      this.redisPubClient,
-      this.chainId
+      this.redisPubClient
     );
     // TODO: use a proper logger
     console.log(
       `${new Date(Date.now()).toISOString()}: executor MarketData initialized ` +
-        `(cache=${usedCache}${usedCache ? `, age=${cacheAgeMs}ms` : ""}, providerIndex=${providerIndex})`
+        `(cache=${usedCache}${usedCache ? `, age=${typeof cacheAgeMs === "number" ? `${cacheAgeMs}ms` : "unknown"}` : ""}, providerIndex=${providerIndex})`
     );
     await initLiquidatorsFromMarketData(this.bots, md, this.providers[providerIndex]);
 

--- a/src/executor/liquidator.ts
+++ b/src/executor/liquidator.ts
@@ -1,7 +1,8 @@
-import { LiquidatorTool, PerpetualDataHandler } from "@d8-x/d8x-node-sdk";
+import { LiquidatorTool, MarketData, NodeSDKConfig, PerpetualDataHandler } from "@d8-x/d8x-node-sdk";
 import { Network, Provider, TransactionResponse, Wallet, formatUnits } from "ethers";
 import { Redis } from "ioredis";
 import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
+import { initLiquidatorsFromMarketData, initMarketDataWithCache } from "../sdkInit.js";
 import { BotStatus, LiquidateTraderMsg, LiquidatorConfig } from "../types.js";
 import { constructRedis, executeWithTimeout, sleep } from "../utils.js";
 import { Metrics } from "./metrics.js";
@@ -27,6 +28,7 @@ export default class Liquidator {
   private config: LiquidatorConfig;
   private earnings: string | undefined;
   private chainId: number;
+  private sdkConfig: NodeSDKConfig;
   private gasPriceBuffer = 100n; // no buffer
   private lastUsedRpcIndex: number = 0;
 
@@ -51,6 +53,7 @@ export default class Liquidator {
     this.redisPubClient = constructRedis("executorPubClient");
 
     const sdkConfig = PerpetualDataHandler.readSDKConfig(this.config.sdkConfig);
+    this.sdkConfig = sdkConfig;
     this.chainId = sdkConfig.chainId;
     this.providers = [
       new MultiUrlJsonRpcProvider(this.config.rpcExec, new Network(sdkConfig.name || "", sdkConfig.chainId), {
@@ -99,26 +102,19 @@ export default class Liquidator {
    * An error is thrown if none of the providers works.
    */
   public async initialize() {
-    // Create a proxy instance to access the blockchain
-    let success = false;
-    let i = Math.floor(Math.random() * this.providers.length);
-    let tried = 0;
-    // try all providers until one works, reverts otherwise
-    // console.log(`${new Date(Date.now()).toISOString()}: initializing ...`);
-    while (!success && i < this.providers.length && tried <= this.providers.length) {
-      console.log(`trying provider ${i} ... `);
-      const results = await Promise.allSettled(
-        // createProxyInstance attaches the given provider to the object instance
-        this.bots.map((liq) => liq.api.createProxyInstance(this.providers[i]), this)
-      );
-
-      success = results.every((r) => r.status === "fulfilled");
-      i = (i + 1) % this.providers.length;
-      tried++;
-    }
-    if (!success) {
-      throw new Error("critical: all RPCs are down");
-    }
+    const md = new MarketData(this.sdkConfig);
+    const { usedCache, providerIndex } = await initMarketDataWithCache(
+      md,
+      this.providers,
+      this.redisPubClient,
+      this.chainId
+    );
+    // TODO: use a proper logger
+    console.log(
+      `${new Date(Date.now()).toISOString()}: executor MarketData initialized ` +
+        `(cache=${usedCache}, providerIndex=${providerIndex})`
+    );
+    await initLiquidatorsFromMarketData(this.bots, md);
 
     // Subscribe to relayed events
     // console.log(`${new Date(Date.now()).toISOString()}: subscribing to account streamer...`);

--- a/src/executor/liquidator.ts
+++ b/src/executor/liquidator.ts
@@ -114,7 +114,7 @@ export default class Liquidator {
       `${new Date(Date.now()).toISOString()}: executor MarketData initialized ` +
         `(cache=${usedCache}, providerIndex=${providerIndex})`
     );
-    await initLiquidatorsFromMarketData(this.bots, md, this.providers[providerIndex] ?? this.providers[0]);
+    await initLiquidatorsFromMarketData(this.bots, md, this.providers[providerIndex]);
 
     // Subscribe to relayed events
     // console.log(`${new Date(Date.now()).toISOString()}: subscribing to account streamer...`);

--- a/src/executor/liquidator.ts
+++ b/src/executor/liquidator.ts
@@ -2,7 +2,7 @@ import { LiquidatorTool, MarketData, NodeSDKConfig, PerpetualDataHandler } from 
 import { Network, Provider, TransactionResponse, Wallet, formatUnits } from "ethers";
 import { Redis } from "ioredis";
 import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
-import { initLiquidatorsFromMarketData, initMarketDataWithCache } from "../sdkInit.js";
+import { formatCacheAgeSuffix, initLiquidatorsFromMarketData, initMarketDataWithCache } from "../sdkInit.js";
 import { BotStatus, LiquidateTraderMsg, LiquidatorConfig } from "../types.js";
 import { constructRedis, executeWithTimeout, sleep } from "../utils.js";
 import { Metrics } from "./metrics.js";
@@ -103,17 +103,13 @@ export default class Liquidator {
    */
   public async initialize() {
     const md = new MarketData(this.sdkConfig);
-    const { usedCache, providerIndex, cacheAgeMs } = await initMarketDataWithCache(
-      md,
-      this.providers,
-      this.redisPubClient
-    );
+    const result = await initMarketDataWithCache(md, this.providers, this.redisPubClient);
     // TODO: use a proper logger
     console.log(
       `${new Date(Date.now()).toISOString()}: executor MarketData initialized ` +
-        `(cache=${usedCache}${usedCache ? `, age=${typeof cacheAgeMs === "number" ? `${cacheAgeMs}ms` : "unknown"}` : ""}, providerIndex=${providerIndex})`
+        `(cache=${result.usedCache}${formatCacheAgeSuffix(result)}, providerIndex=${result.providerIndex})`
     );
-    await initLiquidatorsFromMarketData(this.bots, md, this.providers[providerIndex]);
+    await initLiquidatorsFromMarketData(this.bots, md, this.providers[result.providerIndex]);
 
     // Subscribe to relayed events
     // console.log(`${new Date(Date.now()).toISOString()}: subscribing to account streamer...`);

--- a/src/executor/liquidator.ts
+++ b/src/executor/liquidator.ts
@@ -114,7 +114,7 @@ export default class Liquidator {
       `${new Date(Date.now()).toISOString()}: executor MarketData initialized ` +
         `(cache=${usedCache}, providerIndex=${providerIndex})`
     );
-    await initLiquidatorsFromMarketData(this.bots, md);
+    await initLiquidatorsFromMarketData(this.bots, md, this.providers[providerIndex] ?? this.providers[0]);
 
     // Subscribe to relayed events
     // console.log(`${new Date(Date.now()).toISOString()}: subscribing to account streamer...`);

--- a/src/executor/liquidator.ts
+++ b/src/executor/liquidator.ts
@@ -103,7 +103,7 @@ export default class Liquidator {
    */
   public async initialize() {
     const md = new MarketData(this.sdkConfig);
-    const { usedCache, providerIndex } = await initMarketDataWithCache(
+    const { usedCache, providerIndex, cacheAgeMs } = await initMarketDataWithCache(
       md,
       this.providers,
       this.redisPubClient,
@@ -112,7 +112,7 @@ export default class Liquidator {
     // TODO: use a proper logger
     console.log(
       `${new Date(Date.now()).toISOString()}: executor MarketData initialized ` +
-        `(cache=${usedCache}, providerIndex=${providerIndex})`
+        `(cache=${usedCache}${usedCache ? `, age=${cacheAgeMs}ms` : ""}, providerIndex=${providerIndex})`
     );
     await initLiquidatorsFromMarketData(this.bots, md, this.providers[providerIndex]);
 

--- a/src/executor/main.ts
+++ b/src/executor/main.ts
@@ -35,7 +35,7 @@ async function run() {
   }
   await liquidator.initialize();
 
-  liquidator.run();
+  await liquidator.run();
 }
 
 run().catch((err) => {

--- a/src/executor/main.ts
+++ b/src/executor/main.ts
@@ -38,4 +38,9 @@ async function run() {
   liquidator.run();
 }
 
-run();
+run().catch((err) => {
+  console.error(
+    `${new Date().toISOString()}: executor fatal: ${err instanceof Error ? err.stack ?? err.message : String(err)}`
+  );
+  process.exit(1);
+});

--- a/src/sdkInit.ts
+++ b/src/sdkInit.ts
@@ -37,7 +37,9 @@ export async function initMarketDataWithCache(
     }
   }
   let lastErr: unknown;
-  for (let i = 0; i < providers.length; i++) {
+  
+  let i = providers.length > 0 ? Math.floor(Math.random() * providers.length) : 0;
+  for (let k = 0; k < providers.length; k++, i = (i + 1) % providers.length) {
     try {
       await md.createProxyInstance(providers[i]);
       return { usedCache: false, providerIndex: i };

--- a/src/sdkInit.ts
+++ b/src/sdkInit.ts
@@ -57,6 +57,11 @@ export async function initLiquidatorsFromMarketData(
   }
 }
 
+// TODO: to drop this hack once the SDK's `WriteAccessHandler.createProxyInstance(marketData)` overload accepts an
+// explicit provider. 
+// The MarketData path currently discards any provider attached to the MarketData 
+// and builds a single URL JsonRpcProvider from `md.config.nodeURL`, which kills multi URL failover on reads like `proxyContract.staticCall(...)`.
+// Until that SDK change lands we rebind the bot's contract handles and signer to our multURL provider here here
 function rebindBotProvider(bot: LiquidatorTool, md: MarketData, provider: Provider): void {
   const anyBot = bot as unknown as {
     provider: Provider;

--- a/src/sdkInit.ts
+++ b/src/sdkInit.ts
@@ -25,16 +25,24 @@ export async function initMarketDataWithCache(
   redis: Redis,
   chainId: number
 ): Promise<MarketDataInitResult> {
+  if (providers.length === 0) {
+    throw new Error("no providers configured");
+  }
   const cached = await loadSDKState(redis, { chainId, proxyAddr: md.getProxyAddress() });
   if (cached) {
-    try {
-      await md.createProxyInstanceFromState(cached.state, providers[0]);
-      return { usedCache: true, providerIndex: 0, cacheAgeMs: cached.ageMs };
-    } catch (e) {
-      console.log(
-        `${new Date(Date.now()).toISOString()}: cached SDK state unusable, falling back to full init: ${String(e)}`
-      );
+    let lastCacheErr: unknown;
+    let j = providers.length > 0 ? Math.floor(Math.random() * providers.length) : 0;
+    for (let k = 0; k < providers.length; k++, j = (j + 1) % providers.length) {
+      try {
+        await md.createProxyInstanceFromState(cached.state, providers[j]);
+        return { usedCache: true, providerIndex: j, cacheAgeMs: cached.ageMs };
+      } catch (e) {
+        lastCacheErr = e;
+      }
     }
+    console.log(
+      `${new Date(Date.now()).toISOString()}: cached SDK state unusable across all providers, falling back to full init: ${String(lastCacheErr)}`
+    );
   }
   let lastErr: unknown;
 

--- a/src/sdkInit.ts
+++ b/src/sdkInit.ts
@@ -12,6 +12,7 @@ import { loadSDKState } from "./sdkState.js";
 export interface MarketDataInitResult {
   usedCache: boolean;
   providerIndex: number;
+  cacheAgeMs?: number;
 }
 
 /**
@@ -24,11 +25,11 @@ export async function initMarketDataWithCache(
   redis: Redis,
   chainId: number
 ): Promise<MarketDataInitResult> {
-  const state = await loadSDKState(redis, chainId);
-  if (state) {
+  const cached = await loadSDKState(redis, chainId);
+  if (cached) {
     try {
-      await md.createProxyInstanceFromState(state, providers[0]);
-      return { usedCache: true, providerIndex: 0 };
+      await md.createProxyInstanceFromState(cached.state, providers[0]);
+      return { usedCache: true, providerIndex: 0, cacheAgeMs: cached.ageMs };
     } catch (e) {
       console.log(
         `${new Date(Date.now()).toISOString()}: cached SDK state unusable, falling back to full init: ${String(e)}`

--- a/src/sdkInit.ts
+++ b/src/sdkInit.ts
@@ -104,4 +104,10 @@ function rebindBotProvider(bot: LiquidatorTool, md: MarketData, provider: Provid
   if (providerUrl) {
     anyBot.nodeURL = providerUrl;
   }
+
+  if (!anyBot.proxyContract || !anyBot.multicall || anyBot.provider !== provider) {
+    throw new Error(
+      "rebindBotProvider: LiquidatorTool internal fields missing or unchanged — SDK layout likely changed, audit WriteAccessHandler"
+    );
+  }
 }

--- a/src/sdkInit.ts
+++ b/src/sdkInit.ts
@@ -26,8 +26,14 @@ export async function initMarketDataWithCache(
 ): Promise<MarketDataInitResult> {
   const state = await loadSDKState(redis, chainId);
   if (state) {
-    await md.createProxyInstanceFromState(state, providers[0]);
-    return { usedCache: true, providerIndex: 0 };
+    try {
+      await md.createProxyInstanceFromState(state, providers[0]);
+      return { usedCache: true, providerIndex: 0 };
+    } catch (e) {
+      console.log(
+        `${new Date(Date.now()).toISOString()}: cached SDK state unusable, falling back to full init: ${String(e)}`
+      );
+    }
   }
   let lastErr: unknown;
   for (let i = 0; i < providers.length; i++) {
@@ -70,6 +76,7 @@ function rebindBotProvider(bot: LiquidatorTool, md: MarketData, provider: Provid
     multicall: ReturnType<typeof Multicall3__factory.connect>;
     signer: { connect: (p: Provider) => unknown } | null;
     config: { multicall?: string };
+    nodeURL: string;
   };
   anyBot.provider = provider;
   anyBot.signerOrProvider = provider;
@@ -77,5 +84,12 @@ function rebindBotProvider(bot: LiquidatorTool, md: MarketData, provider: Provid
   anyBot.multicall = Multicall3__factory.connect(anyBot.config.multicall ?? MULTICALL_ADDRESS, provider);
   if (anyBot.signer) {
     anyBot.signer = anyBot.signer.connect(provider) as typeof anyBot.signer;
+  }
+  // Align nodeURL with the rebound provider so any SDK method that falls back
+  // to `this.nodeURL` (when no rpcURL override is passed) doesn't hit the
+  // stale single URL that the MarketData overload copied from md.config.
+  const providerUrl = (provider as unknown as { _getConnection?: () => { url: string } })._getConnection?.().url;
+  if (providerUrl) {
+    anyBot.nodeURL = providerUrl;
   }
 }

--- a/src/sdkInit.ts
+++ b/src/sdkInit.ts
@@ -22,16 +22,18 @@ export interface MarketDataInitResult {
 export async function initMarketDataWithCache(
   md: MarketData,
   providers: Provider[],
-  redis: Redis,
-  chainId: number
+  redis: Redis
 ): Promise<MarketDataInitResult> {
   if (providers.length === 0) {
     throw new Error("no providers configured");
   }
-  const cached = await loadSDKState(redis, { chainId, proxyAddr: md.getProxyAddress() });
+  const cached = await loadSDKState(redis, {
+    chainId: md.config.chainId,
+    proxyAddr: md.getProxyAddress(),
+  });
   if (cached) {
     let lastCacheErr: unknown;
-    let j = providers.length > 0 ? Math.floor(Math.random() * providers.length) : 0;
+    let j = Math.floor(Math.random() * providers.length);
     for (let k = 0; k < providers.length; k++, j = (j + 1) % providers.length) {
       try {
         await md.createProxyInstanceFromState(cached.state, providers[j]);
@@ -45,8 +47,7 @@ export async function initMarketDataWithCache(
     );
   }
   let lastErr: unknown;
-
-  let i = providers.length > 0 ? Math.floor(Math.random() * providers.length) : 0;
+  let i = Math.floor(Math.random() * providers.length);
   for (let k = 0; k < providers.length; k++, i = (i + 1) % providers.length) {
     try {
       await md.createProxyInstance(providers[i]);

--- a/src/sdkInit.ts
+++ b/src/sdkInit.ts
@@ -76,8 +76,9 @@ export async function initLiquidatorsFromMarketData(
   provider: Provider
 ): Promise<void> {
   await Promise.all(bots.map((b) => b.api.createProxyInstance(md)));
+  const proxyAddr = md.getProxyAddress();
   for (const { api } of bots) {
-    rebindBotProvider(api, md, provider);
+    rebindBotProvider(api, proxyAddr, provider);
   }
 }
 
@@ -86,7 +87,7 @@ export async function initLiquidatorsFromMarketData(
 // The MarketData path currently discards any provider attached to the MarketData 
 // and builds a single URL JsonRpcProvider from `md.config.nodeURL`, which kills multi URL failover on reads like `proxyContract.staticCall(...)`.
 // Until that SDK change lands we rebind the bot's contract handles and signer to our multURL provider here here
-function rebindBotProvider(bot: LiquidatorTool, md: MarketData, provider: Provider): void {
+function rebindBotProvider(bot: LiquidatorTool, proxyAddr: string, provider: Provider): void {
   const anyBot = bot as unknown as {
     provider: Provider;
     signerOrProvider: Provider;
@@ -98,7 +99,7 @@ function rebindBotProvider(bot: LiquidatorTool, md: MarketData, provider: Provid
   };
   anyBot.provider = provider;
   anyBot.signerOrProvider = provider;
-  anyBot.proxyContract = IPerpetualManager__factory.connect(md.getProxyAddress(), provider);
+  anyBot.proxyContract = IPerpetualManager__factory.connect(proxyAddr, provider);
   anyBot.multicall = Multicall3__factory.connect(anyBot.config.multicall ?? MULTICALL_ADDRESS, provider);
   if (anyBot.signer) {
     anyBot.signer = anyBot.signer.connect(provider) as typeof anyBot.signer;

--- a/src/sdkInit.ts
+++ b/src/sdkInit.ts
@@ -25,7 +25,7 @@ export async function initMarketDataWithCache(
   redis: Redis,
   chainId: number
 ): Promise<MarketDataInitResult> {
-  const cached = await loadSDKState(redis, chainId);
+  const cached = await loadSDKState(redis, { chainId, proxyAddr: md.getProxyAddress() });
   if (cached) {
     try {
       await md.createProxyInstanceFromState(cached.state, providers[0]);
@@ -37,7 +37,7 @@ export async function initMarketDataWithCache(
     }
   }
   let lastErr: unknown;
-  
+
   let i = providers.length > 0 ? Math.floor(Math.random() * providers.length) : 0;
   for (let k = 0; k < providers.length; k++, i = (i + 1) % providers.length) {
     try {

--- a/src/sdkInit.ts
+++ b/src/sdkInit.ts
@@ -1,10 +1,4 @@
-import {
-  IPerpetualManager__factory,
-  LiquidatorTool,
-  MarketData,
-  MULTICALL_ADDRESS,
-  Multicall3__factory,
-} from "@d8-x/d8x-node-sdk";
+import { LiquidatorTool, MarketData } from "@d8-x/d8x-node-sdk";
 import { Provider } from "ethers";
 import { Redis } from "ioredis";
 import { loadSDKState } from "./sdkState.js";
@@ -75,46 +69,5 @@ export async function initLiquidatorsFromMarketData(
   md: MarketData,
   provider: Provider
 ): Promise<void> {
-  await Promise.all(bots.map((b) => b.api.createProxyInstance(md)));
-  const proxyAddr = md.getProxyAddress();
-  for (const { api } of bots) {
-    rebindBotProvider(api, proxyAddr, provider);
-  }
-}
-
-// TODO: to drop this hack once the SDK's `WriteAccessHandler.createProxyInstance(marketData)` overload accepts an
-// explicit provider. 
-// The MarketData path currently discards any provider attached to the MarketData 
-// and builds a single URL JsonRpcProvider from `md.config.nodeURL`, which kills multi URL failover on reads like `proxyContract.staticCall(...)`.
-// Until that SDK change lands we rebind the bot's contract handles and signer to our multURL provider here here
-function rebindBotProvider(bot: LiquidatorTool, proxyAddr: string, provider: Provider): void {
-  const anyBot = bot as unknown as {
-    provider: Provider;
-    signerOrProvider: Provider;
-    proxyContract: ReturnType<typeof IPerpetualManager__factory.connect>;
-    multicall: ReturnType<typeof Multicall3__factory.connect>;
-    signer: { connect: (p: Provider) => unknown } | null;
-    config: { multicall?: string };
-    nodeURL: string;
-  };
-  anyBot.provider = provider;
-  anyBot.signerOrProvider = provider;
-  anyBot.proxyContract = IPerpetualManager__factory.connect(proxyAddr, provider);
-  anyBot.multicall = Multicall3__factory.connect(anyBot.config.multicall ?? MULTICALL_ADDRESS, provider);
-  if (anyBot.signer) {
-    anyBot.signer = anyBot.signer.connect(provider) as typeof anyBot.signer;
-  }
-  // Align nodeURL with the rebound provider so any SDK method that falls back
-  // to `this.nodeURL` (when no rpcURL override is passed) doesn't hit the
-  // stale single URL that the MarketData overload copied from md.config.
-  const providerUrl = (provider as unknown as { _getConnection?: () => { url: string } })._getConnection?.().url;
-  if (providerUrl) {
-    anyBot.nodeURL = providerUrl;
-  }
-
-  if (!anyBot.proxyContract || !anyBot.multicall || anyBot.provider !== provider) {
-    throw new Error(
-      "rebindBotProvider: LiquidatorTool internal fields missing or unchanged — SDK layout likely changed, audit WriteAccessHandler"
-    );
-  }
+  await Promise.all(bots.map((b) => b.api.createProxyInstance(md, provider)));
 }

--- a/src/sdkInit.ts
+++ b/src/sdkInit.ts
@@ -15,6 +15,12 @@ export interface MarketDataInitResult {
   cacheAgeMs?: number;
 }
 
+export function formatCacheAgeSuffix(result: MarketDataInitResult): string {
+  if (!result.usedCache) return "";
+  const age = typeof result.cacheAgeMs === "number" ? `${result.cacheAgeMs}ms` : "unknown";
+  return `, age=${age}`;
+}
+
 /**
  * Initialize MarketData without RPC when a cached SDK state is available in Redis.
  * Falls back to createProxyInstance(provider) retried across the given providers.

--- a/src/sdkInit.ts
+++ b/src/sdkInit.ts
@@ -35,7 +35,7 @@ export async function initMarketDataWithCache(
   }
   const cached = await loadSDKState(redis, {
     chainId: md.config.chainId,
-    proxyAddr: md.getProxyAddress(),
+    proxyAddr: md.config.proxyAddr,
   });
   if (cached) {
     let lastCacheErr: unknown;

--- a/src/sdkInit.ts
+++ b/src/sdkInit.ts
@@ -1,4 +1,10 @@
-import { LiquidatorTool, MarketData } from "@d8-x/d8x-node-sdk";
+import {
+  IPerpetualManager__factory,
+  LiquidatorTool,
+  MarketData,
+  MULTICALL_ADDRESS,
+  Multicall3__factory,
+} from "@d8-x/d8x-node-sdk";
 import { Provider } from "ethers";
 import { Redis } from "ioredis";
 import { loadSDKState } from "./sdkState.js";
@@ -32,7 +38,7 @@ export async function initMarketDataWithCache(
       lastErr = e;
     }
   }
-  throw new Error(`all RPCs are down: ${lastErr}`);
+  throw new Error(`all RPCs are down: ${String(lastErr)}`);
 }
 
 /**
@@ -42,7 +48,29 @@ export async function initMarketDataWithCache(
  */
 export async function initLiquidatorsFromMarketData(
   bots: { api: LiquidatorTool }[],
-  md: MarketData
+  md: MarketData,
+  provider: Provider
 ): Promise<void> {
   await Promise.all(bots.map((b) => b.api.createProxyInstance(md)));
+  for (const { api } of bots) {
+    rebindBotProvider(api, md, provider);
+  }
+}
+
+function rebindBotProvider(bot: LiquidatorTool, md: MarketData, provider: Provider): void {
+  const anyBot = bot as unknown as {
+    provider: Provider;
+    signerOrProvider: Provider;
+    proxyContract: ReturnType<typeof IPerpetualManager__factory.connect>;
+    multicall: ReturnType<typeof Multicall3__factory.connect>;
+    signer: { connect: (p: Provider) => unknown } | null;
+    config: { multicall?: string };
+  };
+  anyBot.provider = provider;
+  anyBot.signerOrProvider = provider;
+  anyBot.proxyContract = IPerpetualManager__factory.connect(md.getProxyAddress(), provider);
+  anyBot.multicall = Multicall3__factory.connect(anyBot.config.multicall ?? MULTICALL_ADDRESS, provider);
+  if (anyBot.signer) {
+    anyBot.signer = anyBot.signer.connect(provider) as typeof anyBot.signer;
+  }
 }

--- a/src/sdkInit.ts
+++ b/src/sdkInit.ts
@@ -1,0 +1,48 @@
+import { LiquidatorTool, MarketData } from "@d8-x/d8x-node-sdk";
+import { Provider } from "ethers";
+import { Redis } from "ioredis";
+import { loadSDKState } from "./sdkState.js";
+
+export interface MarketDataInitResult {
+  usedCache: boolean;
+  providerIndex: number;
+}
+
+/**
+ * Initialize MarketData without RPC when a cached SDK state is available in Redis.
+ * Falls back to createProxyInstance(provider) retried across the given providers.
+ */
+export async function initMarketDataWithCache(
+  md: MarketData,
+  providers: Provider[],
+  redis: Redis,
+  chainId: number
+): Promise<MarketDataInitResult> {
+  const state = await loadSDKState(redis, chainId);
+  if (state) {
+    await md.createProxyInstanceFromState(state, providers[0]);
+    return { usedCache: true, providerIndex: 0 };
+  }
+  let lastErr: unknown;
+  for (let i = 0; i < providers.length; i++) {
+    try {
+      await md.createProxyInstance(providers[i]);
+      return { usedCache: false, providerIndex: i };
+    } catch (e) {
+      lastErr = e;
+    }
+  }
+  throw new Error(`all RPCs are down: ${lastErr}`);
+}
+
+/**
+ * Initialize each LiquidatorTool from an already-initialized MarketData.
+ * perpetual static info, triangulations and contract addresses
+ * are copied from the shared MarketData instance.
+ */
+export async function initLiquidatorsFromMarketData(
+  bots: { api: LiquidatorTool }[],
+  md: MarketData
+): Promise<void> {
+  await Promise.all(bots.map((b) => b.api.createProxyInstance(md)));
+}

--- a/src/sdkState.ts
+++ b/src/sdkState.ts
@@ -1,12 +1,15 @@
 import type { SDKState } from "@d8-x/d8x-node-sdk";
 import { Redis } from "ioredis";
 
+export const SDK_STATE_TTL_SECONDS = 15 * 60;
+export const SDK_STATE_REPUBLISH_SECONDS = 5 * 60;
+
 export function sdkStateKey(chainId: number): string {
   return `sdk-state:${chainId}`;
 }
 
 export async function publishSDKState(redis: Redis, chainId: number, state: SDKState): Promise<void> {
-  await redis.set(sdkStateKey(chainId), JSON.stringify(state));
+  await redis.set(sdkStateKey(chainId), JSON.stringify(state), "EX", SDK_STATE_TTL_SECONDS);
 }
 
 export async function loadSDKState(redis: Redis, chainId: number): Promise<SDKState | null> {

--- a/src/sdkState.ts
+++ b/src/sdkState.ts
@@ -10,11 +10,17 @@ export function sdkStateKey(chainId: number): string {
 
 interface CachedSDKState {
   sdkVersion: string;
+  publishedAt: number; 
   state: SDKState;
 }
 
+export interface LoadedSDKState {
+  state: SDKState;
+  ageMs: number;
+}
+
 export async function publishSDKState(redis: Redis, chainId: number, state: SDKState): Promise<void> {
-  const payload: CachedSDKState = { sdkVersion: D8X_SDK_VERSION, state };
+  const payload: CachedSDKState = { sdkVersion: D8X_SDK_VERSION, publishedAt: Date.now(), state };
   await redis.set(sdkStateKey(chainId), JSON.stringify(payload), "EX", SDK_STATE_TTL_SECONDS);
 }
 
@@ -23,7 +29,7 @@ export async function refreshSDKStateTTL(redis: Redis, chainId: number): Promise
   return result === 1;
 }
 
-export async function loadSDKState(redis: Redis, chainId: number): Promise<SDKState | null> {
+export async function loadSDKState(redis: Redis, chainId: number): Promise<LoadedSDKState | null> {
   const raw = await redis.get(sdkStateKey(chainId));
   if (!raw) return null;
   try {
@@ -31,7 +37,8 @@ export async function loadSDKState(redis: Redis, chainId: number): Promise<SDKSt
     if (parsed?.sdkVersion !== D8X_SDK_VERSION || !parsed.state) {
       return null;
     }
-    return parsed.state;
+    const ageMs = typeof parsed.publishedAt === "number" ? Date.now() - parsed.publishedAt : NaN;
+    return { state: parsed.state, ageMs };
   } catch {
     return null;
   }

--- a/src/sdkState.ts
+++ b/src/sdkState.ts
@@ -18,6 +18,11 @@ export async function publishSDKState(redis: Redis, chainId: number, state: SDKS
   await redis.set(sdkStateKey(chainId), JSON.stringify(payload), "EX", SDK_STATE_TTL_SECONDS);
 }
 
+export async function refreshSDKStateTTL(redis: Redis, chainId: number): Promise<boolean> {
+  const result = await redis.expire(sdkStateKey(chainId), SDK_STATE_TTL_SECONDS);
+  return result === 1;
+}
+
 export async function loadSDKState(redis: Redis, chainId: number): Promise<SDKState | null> {
   const raw = await redis.get(sdkStateKey(chainId));
   if (!raw) return null;

--- a/src/sdkState.ts
+++ b/src/sdkState.ts
@@ -29,12 +29,24 @@ export async function refreshSDKStateTTL(redis: Redis, chainId: number): Promise
   return result === 1;
 }
 
-export async function loadSDKState(redis: Redis, chainId: number): Promise<LoadedSDKState | null> {
-  const raw = await redis.get(sdkStateKey(chainId));
+export interface TrustedAnchors {
+  chainId: number;
+  proxyAddr: string;
+}
+
+export async function loadSDKState(redis: Redis, anchors: TrustedAnchors): Promise<LoadedSDKState | null> {
+  const raw = await redis.get(sdkStateKey(anchors.chainId));
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as Partial<CachedSDKState>;
     if (parsed?.sdkVersion !== D8X_SDK_VERSION || !parsed.state) {
+      return null;
+    }
+    if (parsed.state.chainId !== anchors.chainId) return null;
+    if (
+      typeof parsed.state.proxyAddr !== "string" ||
+      parsed.state.proxyAddr.toLowerCase() !== anchors.proxyAddr.toLowerCase()
+    ) {
       return null;
     }
     const ageMs = typeof parsed.publishedAt === "number" ? Date.now() - parsed.publishedAt : NaN;

--- a/src/sdkState.ts
+++ b/src/sdkState.ts
@@ -1,0 +1,20 @@
+import type { SDKState } from "@d8-x/d8x-node-sdk";
+import { Redis } from "ioredis";
+
+export function sdkStateKey(chainId: number): string {
+  return `sdk-state:${chainId}`;
+}
+
+export async function publishSDKState(redis: Redis, chainId: number, state: SDKState): Promise<void> {
+  await redis.set(sdkStateKey(chainId), JSON.stringify(state));
+}
+
+export async function loadSDKState(redis: Redis, chainId: number): Promise<SDKState | null> {
+  const raw = await redis.get(sdkStateKey(chainId));
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as SDKState;
+  } catch {
+    return null;
+  }
+}

--- a/src/sdkState.ts
+++ b/src/sdkState.ts
@@ -10,13 +10,13 @@ export function sdkStateKey(chainId: number): string {
 
 interface CachedSDKState {
   sdkVersion: string;
-  publishedAt: number; 
+  publishedAt: number;
   state: SDKState;
 }
 
 export interface LoadedSDKState {
   state: SDKState;
-  ageMs: number;
+  ageMs?: number;
 }
 
 export async function publishSDKState(redis: Redis, chainId: number, state: SDKState): Promise<void> {
@@ -49,7 +49,7 @@ export async function loadSDKState(redis: Redis, anchors: TrustedAnchors): Promi
     ) {
       return null;
     }
-    const ageMs = typeof parsed.publishedAt === "number" ? Date.now() - parsed.publishedAt : NaN;
+    const ageMs = typeof parsed.publishedAt === "number" ? Date.now() - parsed.publishedAt : undefined;
     return { state: parsed.state, ageMs };
   } catch {
     return null;

--- a/src/sdkState.ts
+++ b/src/sdkState.ts
@@ -1,5 +1,6 @@
 import { D8X_SDK_VERSION, type SDKState } from "@d8-x/d8x-node-sdk";
 import { Redis } from "ioredis";
+import { stableStringify } from "./utils.js";
 
 export const SDK_STATE_TTL_SECONDS = 15 * 60;
 export const SDK_STATE_REPUBLISH_SECONDS = 5 * 60;
@@ -21,7 +22,7 @@ export interface LoadedSDKState {
 
 export async function publishSDKState(redis: Redis, chainId: number, state: SDKState): Promise<void> {
   const payload: CachedSDKState = { sdkVersion: D8X_SDK_VERSION, publishedAt: Date.now(), state };
-  await redis.set(sdkStateKey(chainId), JSON.stringify(payload), "EX", SDK_STATE_TTL_SECONDS);
+  await redis.set(sdkStateKey(chainId), stableStringify(payload), "EX", SDK_STATE_TTL_SECONDS);
 }
 
 export async function refreshSDKStateTTL(redis: Redis, chainId: number): Promise<boolean> {

--- a/src/sdkState.ts
+++ b/src/sdkState.ts
@@ -1,4 +1,4 @@
-import type { SDKState } from "@d8-x/d8x-node-sdk";
+import { D8X_SDK_VERSION, type SDKState } from "@d8-x/d8x-node-sdk";
 import { Redis } from "ioredis";
 
 export const SDK_STATE_TTL_SECONDS = 15 * 60;
@@ -8,15 +8,25 @@ export function sdkStateKey(chainId: number): string {
   return `sdk-state:${chainId}`;
 }
 
+interface CachedSDKState {
+  sdkVersion: string;
+  state: SDKState;
+}
+
 export async function publishSDKState(redis: Redis, chainId: number, state: SDKState): Promise<void> {
-  await redis.set(sdkStateKey(chainId), JSON.stringify(state), "EX", SDK_STATE_TTL_SECONDS);
+  const payload: CachedSDKState = { sdkVersion: D8X_SDK_VERSION, state };
+  await redis.set(sdkStateKey(chainId), JSON.stringify(payload), "EX", SDK_STATE_TTL_SECONDS);
 }
 
 export async function loadSDKState(redis: Redis, chainId: number): Promise<SDKState | null> {
   const raw = await redis.get(sdkStateKey(chainId));
   if (!raw) return null;
   try {
-    return JSON.parse(raw) as SDKState;
+    const parsed = JSON.parse(raw) as Partial<CachedSDKState>;
+    if (parsed?.sdkVersion !== D8X_SDK_VERSION || !parsed.state) {
+      return null;
+    }
+    return parsed.state;
   } catch {
     return null;
   }

--- a/src/sdkState.ts
+++ b/src/sdkState.ts
@@ -1,6 +1,5 @@
 import { D8X_SDK_VERSION, type SDKState } from "@d8-x/d8x-node-sdk";
 import { Redis } from "ioredis";
-import { stableStringify } from "./utils.js";
 
 export const SDK_STATE_TTL_SECONDS = 15 * 60;
 export const SDK_STATE_REPUBLISH_SECONDS = 5 * 60;
@@ -22,7 +21,7 @@ export interface LoadedSDKState {
 
 export async function publishSDKState(redis: Redis, chainId: number, state: SDKState): Promise<void> {
   const payload: CachedSDKState = { sdkVersion: D8X_SDK_VERSION, publishedAt: Date.now(), state };
-  await redis.set(sdkStateKey(chainId), stableStringify(payload), "EX", SDK_STATE_TTL_SECONDS);
+  await redis.set(sdkStateKey(chainId), JSON.stringify(payload), "EX", SDK_STATE_TTL_SECONDS);
 }
 
 export async function refreshSDKStateTTL(redis: Redis, chainId: number): Promise<boolean> {

--- a/src/sentinel/blockchainListener.ts
+++ b/src/sentinel/blockchainListener.ts
@@ -217,13 +217,16 @@ export default class BlockhainListener {
       "could not establish http connection"
     );
 
-    const { usedCache } = await initMarketDataWithCache(
+    const { usedCache, cacheAgeMs } = await initMarketDataWithCache(
       this.md,
       [this.httpProvider],
       this.redisPubClient,
       Number(this.network.chainId)
     );
-    console.log(`${new Date(Date.now()).toISOString()}: sentinel MarketData initialized (cache=${usedCache})`);
+    console.log(
+      `${new Date(Date.now()).toISOString()}: sentinel MarketData initialized ` +
+        `(cache=${usedCache}${usedCache ? `, age=${cacheAgeMs}ms` : ""})`
+    );
 
     if (this.config.rpcListenWs.length > 0) {
       this.listeningProvider = this.multiUrlWsProvider;

--- a/src/sentinel/blockchainListener.ts
+++ b/src/sentinel/blockchainListener.ts
@@ -220,12 +220,11 @@ export default class BlockhainListener {
     const { usedCache, cacheAgeMs } = await initMarketDataWithCache(
       this.md,
       [this.httpProvider],
-      this.redisPubClient,
-      Number(this.network.chainId)
+      this.redisPubClient
     );
     console.log(
       `${new Date(Date.now()).toISOString()}: sentinel MarketData initialized ` +
-        `(cache=${usedCache}${usedCache ? `, age=${cacheAgeMs}ms` : ""})`
+        `(cache=${usedCache}${usedCache ? `, age=${typeof cacheAgeMs === "number" ? `${cacheAgeMs}ms` : "unknown"}` : ""})`
     );
 
     if (this.config.rpcListenWs.length > 0) {

--- a/src/sentinel/blockchainListener.ts
+++ b/src/sentinel/blockchainListener.ts
@@ -8,7 +8,7 @@ import { constructRedis, executeWithTimeout, sleep } from "../utils.js";
 import { JsonRpcProvider, Network, SocketProvider, WebSocketProvider } from "ethers";
 import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
 import { MultiUrlWebSocketProvider } from "../multiUrlWebsocketProvider.js";
-import { initMarketDataWithCache } from "../sdkInit.js";
+import { formatCacheAgeSuffix, initMarketDataWithCache } from "../sdkInit.js";
 
 enum ListeningMode {
   Polling = "Polling",
@@ -217,14 +217,10 @@ export default class BlockhainListener {
       "could not establish http connection"
     );
 
-    const { usedCache, cacheAgeMs } = await initMarketDataWithCache(
-      this.md,
-      [this.httpProvider],
-      this.redisPubClient
-    );
+    const result = await initMarketDataWithCache(this.md, [this.httpProvider], this.redisPubClient);
     console.log(
       `${new Date(Date.now()).toISOString()}: sentinel MarketData initialized ` +
-        `(cache=${usedCache}${usedCache ? `, age=${typeof cacheAgeMs === "number" ? `${cacheAgeMs}ms` : "unknown"}` : ""})`
+        `(cache=${result.usedCache}${formatCacheAgeSuffix(result)})`
     );
 
     if (this.config.rpcListenWs.length > 0) {

--- a/src/sentinel/blockchainListener.ts
+++ b/src/sentinel/blockchainListener.ts
@@ -8,6 +8,7 @@ import { constructRedis, executeWithTimeout, sleep } from "../utils.js";
 import { JsonRpcProvider, Network, SocketProvider, WebSocketProvider } from "ethers";
 import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
 import { MultiUrlWebSocketProvider } from "../multiUrlWebsocketProvider.js";
+import { initMarketDataWithCache } from "../sdkInit.js";
 
 enum ListeningMode {
   Polling = "Polling",
@@ -216,7 +217,13 @@ export default class BlockhainListener {
       "could not establish http connection"
     );
 
-    await this.md.createProxyInstance(this.httpProvider);
+    const { usedCache } = await initMarketDataWithCache(
+      this.md,
+      [this.httpProvider],
+      this.redisPubClient,
+      Number(this.network.chainId)
+    );
+    console.log(`${new Date(Date.now()).toISOString()}: sentinel MarketData initialized (cache=${usedCache})`);
 
     if (this.config.rpcListenWs.length > 0) {
       this.listeningProvider = this.multiUrlWsProvider;

--- a/src/sentinel/main.ts
+++ b/src/sentinel/main.ts
@@ -9,7 +9,12 @@ async function start() {
   }
   const cfg = await loadConfig(sdkConfig);
   const eventStreamer = new BlockhainListener(cfg);
-  eventStreamer.start();
+  await eventStreamer.start();
 }
 
-start();
+start().catch((err) => {
+  console.error(
+    `${new Date().toISOString()}: sentinel fatal: ${err instanceof Error ? err.stack ?? err.message : String(err)}`
+  );
+  process.exit(1);
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,3 +102,16 @@ export function executeWithTimeout<T>(
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      const sorted: Record<string, unknown> = {};
+      for (const k of Object.keys(val as Record<string, unknown>).sort()) {
+        sorted[k] = (val as Record<string, unknown>)[k];
+      }
+      return sorted;
+    }
+    return val;
+  });
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,8 +106,16 @@ export function sleep(ms: number) {
 export function stableStringify(value: unknown): string {
   return JSON.stringify(value, (_key, val) => {
     if (typeof val === "bigint") return val.toString();
-    if (val instanceof Map) return Array.from(val.entries());
-    if (val instanceof Set) return Array.from(val.values());
+    if (val instanceof Map) {
+      return Array.from(val.entries()).sort((a, b) =>
+        JSON.stringify(a[0]).localeCompare(JSON.stringify(b[0]))
+      );
+    }
+    if (val instanceof Set) {
+      return Array.from(val.values()).sort((a, b) =>
+        JSON.stringify(a).localeCompare(JSON.stringify(b))
+      );
+    }
     if (val && typeof val === "object" && !Array.isArray(val)) {
       const sorted: Record<string, unknown> = {};
       for (const k of Object.keys(val as Record<string, unknown>).sort()) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,6 +105,9 @@ export function sleep(ms: number) {
 
 export function stableStringify(value: unknown): string {
   return JSON.stringify(value, (_key, val) => {
+    if (typeof val === "bigint") return val.toString();
+    if (val instanceof Map) return Array.from(val.entries());
+    if (val instanceof Set) return Array.from(val.values());
     if (val && typeof val === "object" && !Array.isArray(val)) {
       const sorted: Record<string, unknown> = {};
       for (const k of Object.keys(val as Record<string, unknown>).sort()) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,10 +14,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@d8-x/d8x-node-sdk@0.1.66":
-  version "0.1.66"
-  resolved "https://npm.pkg.github.com/download/@d8-x/d8x-node-sdk/0.1.66/714195912f555fb27866ead30d38b58013ead404#714195912f555fb27866ead30d38b58013ead404"
-  integrity sha512-Nrtw0/d9zgZVKnSHOPu8dRmPAVN46c9LVrvuJOHARMmHmXmrxUn8YxQVaIYkNtvP83HkNTgYReSSGXJPor42cg==
+"@d8-x/d8x-node-sdk@0.1.67":
+  version "0.1.67"
+  resolved "https://npm.pkg.github.com/download/@d8-x/d8x-node-sdk/0.1.67/dbac32eece924291310357ccf8e89f7856833ec1#dbac32eece924291310357ccf8e89f7856833ec1"
+  integrity sha512-/AlJa6F62QfrtjbXUOl1B2CHFjPoP7rCvu6/qisrV7ydKECjtcNEhqQ2Y1tevxWPw9pzQHZURz4yvBPo5X58Ag==
   dependencies:
     "@d8-x/d8x-price-wasm" "^1.0.33"
     "@typechain/ethers-v6" "^0.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,10 +14,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@d8-x/d8x-node-sdk@0.1.58":
-  version "0.1.58"
-  resolved "https://npm.pkg.github.com/download/@d8-x/d8x-node-sdk/0.1.58/01545148f6da024548e4f7f797af7b8443bfc413#01545148f6da024548e4f7f797af7b8443bfc413"
-  integrity sha512-LnEr+AD5aBE7qQyq+c0qjrQ7KqweAO5N1o846RwAA+kC9lUEc9yxB1XPIbTrW97bjyGIZqzGIpk+V4tcRyPhSA==
+"@d8-x/d8x-node-sdk@0.1.66":
+  version "0.1.66"
+  resolved "https://npm.pkg.github.com/download/@d8-x/d8x-node-sdk/0.1.66/714195912f555fb27866ead30d38b58013ead404#714195912f555fb27866ead30d38b58013ead404"
+  integrity sha512-Nrtw0/d9zgZVKnSHOPu8dRmPAVN46c9LVrvuJOHARMmHmXmrxUn8YxQVaIYkNtvP83HkNTgYReSSGXJPor42cg==
   dependencies:
     "@d8-x/d8x-price-wasm" "^1.0.33"
     "@typechain/ethers-v6" "^0.5.1"


### PR DESCRIPTION
This PR Closes #25 
- Introduced a shared SDK state cache in Redis. Commander became the state leader. It does the full init, then publishes snapshots for others.
 - Sentinel bootstraps from the cache, falls back to full init if the cache is missing or unusable.
 - Executor now shares a single MarketData across all bots, replacing per-bot full init. (we run this with 5 bots)
  - Commander now throws a clear fatal on `all RPCs down` instead of logging and crashing later ..
  - Added Controlled exit paths. Every service's entry point catches init failures and exits with a clean fatal log.
  - awaited Sentinel's start (it think the await was forgoten) so rejections actually surface .. 