### PR TITLE
update watchlist on settlevents and on sdk refresh

### DIFF
--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -54,6 +54,10 @@ export default class Distributor {
   private lastPublishedState: string | undefined;
   private lastPublishedWatchlist: string | undefined;
   private reconcileInflight: Promise<void> | null = null;
+  private lastReconcileAt = 0;
+  private static readonly RECONCILE_TICK_MS = 60 * 1_000;
+  private static readonly RECONCILE_STALE_MS = 30 * 60 * 1_000;
+  private static readonly RECONCILE_EVENT_MIN_GAP_MS = 2_000;
   public ready: boolean = false;
 
   // static info
@@ -133,6 +137,7 @@ export default class Distributor {
       "UpdateMarginAccountEvent",
       "LiquidateEvent",
       "PerpEmergency",
+      "PerpNormal",
       "listener-error",
       "switch-mode",
       (err, count) => {
@@ -268,8 +273,14 @@ export default class Distributor {
       }, 10_000);
 
       setInterval(() => {
-        void this.reconcileWatchlist();
-      }, 60 * 1_000);
+        if (this.symbols.length === 0) {
+          void this.reconcileWatchlist();
+          return;
+        }
+        if (Date.now() - this.lastReconcileAt > Distributor.RECONCILE_STALE_MS) {
+          void this.reconcileWatchlist();
+        }
+      }, Distributor.RECONCILE_TICK_MS);
 
       this.redisSubClient.on("message", async (channel, msg) => {
         switch (channel) {
@@ -308,6 +319,16 @@ export default class Distributor {
 
           case "PerpEmergency": {
             await this.onPerpEmergency(JSON.parse(msg) as PerpEmergencyMsg);
+            break;
+          }
+
+          case "PerpNormal": {
+            if (
+              !this.reconcileInflight &&
+              Date.now() - this.lastReconcileAt > Distributor.RECONCILE_EVENT_MIN_GAP_MS
+            ) {
+              void this.reconcileWatchlist();
+            }
             break;
           }
 
@@ -522,6 +543,7 @@ export default class Distributor {
 
   private async reconcileWatchlist(): Promise<void> {
     if (this.reconcileInflight) return this.reconcileInflight;
+    this.lastReconcileAt = Date.now();
     this.reconcileInflight = (async () => {
       let info;
       try {

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -268,8 +268,8 @@ export default class Distributor {
       }, 10_000);
 
       setInterval(() => {
-        if (this.symbols.length === 0) void this.reconcileWatchlist();
-      }, 30_000);
+        void this.reconcileWatchlist();
+      }, 60 * 1_000);
 
       this.redisSubClient.on("message", async (channel, msg) => {
         switch (channel) {

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -27,7 +27,7 @@ import {
 } from "../types.js";
 import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
 import { SDK_STATE_REPUBLISH_SECONDS, publishSDKState, refreshSDKStateTTL } from "../sdkState.js";
-import { publishWatchlist } from "../watchlist.js";
+import { loadWatchlist, PerpStates, publishWatchlist, serializePerpStates } from "../watchlist.js";
 
 export default class Distributor {
   // objects
@@ -208,7 +208,21 @@ export default class Distributor {
   }
 
   private async broadcastWatchlist(): Promise<void> {
-    const payload = JSON.stringify([...this.symbols].sort());
+    let info;
+    try {
+      info = await this.md.exchangeInfo();
+    } catch (e) {
+      console.log({ info: "broadcastWatchlist: exchangeInfo failed", error: e instanceof Error ? e.message : String(e) });
+      return;
+    }
+    const states: PerpStates = {};
+    for (const pool of info.pools) {
+      if (!pool.isRunning) continue;
+      for (const p of pool.perpetuals) {
+        states[`${p.baseCurrency}-${p.quoteCurrency}-${pool.poolSymbol}`] = p.state;
+      }
+    }
+    const payload = serializePerpStates(states);
     if (payload === this.lastPublishedWatchlist) return;
     try {
       await publishWatchlist(this.redisPubClient, this.chainId, payload);
@@ -517,24 +531,39 @@ export default class Distributor {
         console.log({ info: "reconcile failed", error: e instanceof Error ? e.message : String(e) });
         return;
       }
-      const desired = info.pools
-        .filter(({ isRunning }) => isRunning)
-        .flatMap((pool) =>
-          pool.perpetuals
-            .filter(({ state }) => state === "NORMAL")
-            .map((p) => `${p.baseCurrency}-${p.quoteCurrency}-${pool.poolSymbol}`)
-        );
-      const before = JSON.stringify([...this.symbols].sort());
-      for (const s of [...this.symbols]) this.dropSymbol(s);
+      const sdkStates: PerpStates = {};
+      for (const pool of info.pools) {
+        if (!pool.isRunning) continue;
+        for (const p of pool.perpetuals) {
+          sdkStates[`${p.baseCurrency}-${p.quoteCurrency}-${pool.poolSymbol}`] = p.state;
+        }
+      }
+      const sdkPayload = serializePerpStates(sdkStates);
+      let redisPayload: string | null = null;
+      try {
+        const redisStates = await loadWatchlist(this.redisPubClient, this.chainId);
+        if (redisStates) redisPayload = serializePerpStates(redisStates);
+      } catch (e) {
+        console.log({ info: "reconcile: loadWatchlist failed", error: e instanceof Error ? e.message : String(e) });
+      }
+      if (redisPayload === sdkPayload && this.lastPublishedWatchlist === sdkPayload) return;
+      try {
+        await publishWatchlist(this.redisPubClient, this.chainId, sdkPayload);
+        this.lastPublishedWatchlist = sdkPayload;
+      } catch (e) {
+        console.log({ info: "reconcile: publish failed", error: e instanceof Error ? e.message : String(e) });
+        return;
+      }
+      const desired = Object.keys(sdkStates).filter((s) => sdkStates[s] === "NORMAL");
+      const desiredSet = new Set(desired);
+      const currentSet = new Set(this.symbols);
+      for (const s of [...this.symbols]) if (!desiredSet.has(s)) this.dropSymbol(s);
       for (const s of desired) {
+        if (currentSet.has(s)) continue;
         try { await this.addSymbol(s); }
         catch (e) { console.log({ info: "addSymbol failed", symbol: s, error: e instanceof Error ? e.message : String(e) }); }
       }
-      const after = JSON.stringify([...this.symbols].sort());
-      if (before !== after) {
-        console.log({ info: "watchlist reconciled", size: this.symbols.length });
-        await this.broadcastWatchlist();
-      }
+      console.log({ info: "watchlist reconciled", size: this.symbols.length });
     })().finally(() => {
       this.reconcileInflight = null;
     });

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -20,13 +20,14 @@ import {
   LiquidateMsg,
   LiquidateTraderMsg,
   LiquidatorConfig,
+  PerpEmergencyMsg,
   Position,
   UpdateMarginAccountMsg,
   UpdateMarkPriceMsg,
-  UpdateUnitAccumulatedFundingMsg,
 } from "../types.js";
 import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
 import { SDK_STATE_REPUBLISH_SECONDS, publishSDKState, refreshSDKStateTTL } from "../sdkState.js";
+import { publishWatchlist } from "../watchlist.js";
 
 export default class Distributor {
   // objects
@@ -45,14 +46,14 @@ export default class Distributor {
 
   // state
   private lastRefreshTime: Map<string, number> = new Map();
-  private lastFundingFetchTime: Map<string, number> = new Map();
   private openPositions: Map<string, Map<string, Position>> = new Map();
   private pxSubmission: Map<string, IdxPriceInfo> = new Map();
   private markPremium: Map<string, number> = new Map();
-  private unitAccumulatedFunding: Map<string, number> = new Map();
-  private messageSentAt: Map<string, number> = new Map();
+  private messageSentAt: Map<string, Map<string, number>> = new Map();
   private pricesFetchedAt: Map<string, number> = new Map();
   private lastPublishedState: string | undefined;
+  private lastPublishedWatchlist: string | undefined;
+  private reconcileInflight: Promise<void> | null = null;
   public ready: boolean = false;
 
   // static info
@@ -121,43 +122,9 @@ export default class Distributor {
       )
       .flat();
 
-    for (const symbol of this.symbols) {
-      // static info
-      this.maintenanceRate.set(
-        symbol,
-        PerpetualDataHandler.getMaintenanceMarginRate(this.md.getPerpetualStaticInfo(symbol))
-      );
-      this.isQuote.set(
-        symbol,
-        this.md.getPerpetualStaticInfo(symbol).collateralCurrencyType == COLLATERAL_CURRENCY_QUOTE
-      );
-      // price info
-      try {
-        const priceInfo = await this.md.fetchPricesForPerpetual(symbol);
-        this.pxSubmission.set(symbol, priceInfo);
-      } catch (e) {
-        this.pxSubmission.set(symbol, {
-          s2: 1,
-          ema: 1,
-          s2MktClosed: true,
-          conf: BigInt(1),
-          predMktCLOBParams: BigInt(1),
-        });
-      }
-      // mark premium, accumulated funding per BC unit
-      const perpState = await this.md.getReadOnlyProxyInstance().getPerpetual(this.md.getPerpIdFromSymbol(symbol));
-      this.markPremium.set(symbol, ABK64x64ToFloat(perpState.currentMarkPremiumRate.fPrice));
-      this.unitAccumulatedFunding.set(symbol, ABK64x64ToFloat(perpState.fUnitAccumulatedFunding));
-      // "preallocate" trader set
-      this.openPositions.set(symbol, new Map());
-      // dummy values
-      this.lastRefreshTime.set(symbol, 0);
-      console.log({
-        symbol: symbol,
-        markPremium: this.markPremium.get(symbol),
-        unitAccumulatedFunding: this.unitAccumulatedFunding.get(symbol),
-      });
-    }
+    const initial = this.symbols;
+    this.symbols = [];
+    for (const symbol of initial) await this.addSymbol(symbol);
 
     // Subscribe to blockchain events
     await this.redisSubClient.subscribe(
@@ -165,6 +132,7 @@ export default class Distributor {
       "UpdateMarkPriceEvent",
       "UpdateMarginAccountEvent",
       "LiquidateEvent",
+      "PerpEmergency",
       "listener-error",
       "switch-mode",
       (err, count) => {
@@ -175,7 +143,49 @@ export default class Distributor {
       },
     );
 
+    await this.broadcastWatchlist();
     this.ready = true;
+  }
+
+  private async addSymbol(symbol: string): Promise<void> {
+    let priceInfo: IdxPriceInfo | undefined;
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        priceInfo = await this.md.fetchPricesForPerpetual(symbol);
+        break;
+      } catch (e) {
+        lastErr = e;
+        if (attempt < 3) await sleepForSec(attempt);
+      }
+    }
+    if (!priceInfo) {
+      console.log({
+        info: "addSymbol: skipping - price fetch failed after retries",
+        time: new Date().toISOString(),
+        symbol,
+        error: lastErr instanceof Error ? lastErr.message : String(lastErr),
+      });
+      return;
+    }
+    const info = this.md.getPerpetualStaticInfo(symbol);
+    this.maintenanceRate.set(symbol, PerpetualDataHandler.getMaintenanceMarginRate(info));
+    this.isQuote.set(symbol, info.collateralCurrencyType == COLLATERAL_CURRENCY_QUOTE);
+    this.pxSubmission.set(symbol, priceInfo);
+    this.openPositions.set(symbol, new Map());
+    this.lastRefreshTime.set(symbol, 0);
+    if (!this.symbols.includes(symbol)) this.symbols.push(symbol);
+  }
+
+  private dropSymbol(symbol: string): boolean {
+    const idx = this.symbols.indexOf(symbol);
+    if (idx < 0) return false;
+    this.symbols.splice(idx, 1);
+    this.openPositions.delete(symbol);
+    this.lastRefreshTime.delete(symbol);
+    this.pricesFetchedAt.delete(symbol);
+    this.messageSentAt.delete(symbol);
+    return true;
   }
 
   private async publishState(): Promise<void> {
@@ -197,10 +207,31 @@ export default class Distributor {
     }
   }
 
+  private async broadcastWatchlist(): Promise<void> {
+    const payload = JSON.stringify([...this.symbols].sort());
+    if (payload === this.lastPublishedWatchlist) return;
+    try {
+      await publishWatchlist(this.redisPubClient, this.chainId, payload);
+      this.lastPublishedWatchlist = payload;
+    } catch (e) {
+      console.log(
+        `${new Date(Date.now()).toISOString()}: failed to publish watchlist: ${
+          e instanceof Error ? e.stack ?? e.message : String(e)
+        }`
+      );
+    }
+  }
+
   private requireReady() {
     if (!this.ready) {
       throw new Error("not ready: await distributor.initialize()");
     }
+  }
+
+  private async onPerpEmergency(msg: PerpEmergencyMsg): Promise<void> {
+    if (!this.dropSymbol(msg.symbol)) return;
+    console.log({ info: "perp dropped", time: new Date().toISOString(), ...msg });
+    await this.broadcastWatchlist();
   }
 
   /**
@@ -222,10 +253,9 @@ export default class Distributor {
         await this.refreshAllAccounts();
       }, 10_000);
 
-      // fetch accumulated funding so that it's fresh often enough
-      setInterval(async () => {
-        await this.refreshUnitAccumulatedFunding();
-      }, 10_000);
+      setInterval(() => {
+        if (this.symbols.length === 0) void this.reconcileWatchlist();
+      }, 30_000);
 
       this.redisSubClient.on("message", async (channel, msg) => {
         switch (channel) {
@@ -262,9 +292,8 @@ export default class Distributor {
             break;
           }
 
-          case "UpdateUnitAccumulatedFundingEvent": {
-            const { symbol, unitAccumulatedFundingCC }: UpdateUnitAccumulatedFundingMsg = JSON.parse(msg);
-            this.unitAccumulatedFunding.set(symbol, unitAccumulatedFundingCC);
+          case "PerpEmergency": {
+            await this.onPerpEmergency(JSON.parse(msg) as PerpEmergencyMsg);
             break;
           }
 
@@ -273,6 +302,7 @@ export default class Distributor {
             await this.fetchPosition(perpetualId, traderAddr).then((pos) => {
               this.updatePosition(pos);
             });
+            break;
           }
 
           case "listener-error":
@@ -326,17 +356,6 @@ export default class Distributor {
       unpaidFundingCC: ABK64x64ToFloat(BigInt(account[3]) - BigInt(account[2])),
     };
     return position;
-  }
-
-  private async refreshUnitAccumulatedFunding() {
-    for (const symbol of this.symbols) {
-      if (Date.now() - (this.lastFundingFetchTime.get(symbol) ?? 0) < this.config.liquidateIntervalSecondsMax * 1_000) {
-        return;
-      }
-      this.lastFundingFetchTime.set(symbol, Date.now());
-      const perp = await this.md.getReadOnlyProxyInstance().getPerpetual(this.md.getPerpIdFromSymbol(symbol)!);
-      this.unitAccumulatedFunding.set(symbol, ABK64x64ToFloat(perp.fUnitAccumulatedFunding));
-    }
   }
 
   private async refreshAllAccounts() {
@@ -487,6 +506,41 @@ export default class Distributor {
     return true;
   }
 
+  private async reconcileWatchlist(): Promise<void> {
+    if (this.reconcileInflight) return this.reconcileInflight;
+    this.reconcileInflight = (async () => {
+      let info;
+      try {
+        await this.md.refreshSymbols(true);
+        info = await this.md.exchangeInfo();
+      } catch (e) {
+        console.log({ info: "reconcile failed", error: e instanceof Error ? e.message : String(e) });
+        return;
+      }
+      const desired = info.pools
+        .filter(({ isRunning }) => isRunning)
+        .flatMap((pool) =>
+          pool.perpetuals
+            .filter(({ state }) => state === "NORMAL")
+            .map((p) => `${p.baseCurrency}-${p.quoteCurrency}-${pool.poolSymbol}`)
+        );
+      const before = JSON.stringify([...this.symbols].sort());
+      for (const s of [...this.symbols]) this.dropSymbol(s);
+      for (const s of desired) {
+        try { await this.addSymbol(s); }
+        catch (e) { console.log({ info: "addSymbol failed", symbol: s, error: e instanceof Error ? e.message : String(e) }); }
+      }
+      const after = JSON.stringify([...this.symbols].sort());
+      if (before !== after) {
+        console.log({ info: "watchlist reconciled", size: this.symbols.length });
+        await this.broadcastWatchlist();
+      }
+    })().finally(() => {
+      this.reconcileInflight = null;
+    });
+    return this.reconcileInflight;
+  }
+
   /**
    * Checks if any accounts can be liquidated and publishes them via redis.
    * No RPC calls are made here, only price service
@@ -503,21 +557,31 @@ export default class Distributor {
     const curPx = this.pxSubmission.get(symbol)!;
     const accountsSent: Set<string> = new Set();
 
+    const candidates: string[] = [];
     for (const trader of positions.keys()) {
-      const position = positions.get(trader)!;
-      if (!this.isMarginSafe(position, curPx)) {
-        const msg = JSON.stringify({
-          chainId: this.chainId,
-          symbol: symbol,
-          traderAddr: trader,
-        });
-        if (Date.now() - (this.messageSentAt.get(msg) ?? 0) > this.config.liquidateIntervalSecondsMin * 1_000) {
-          // this.logPosition(position, [curPx.s2, curPx.s3]);
-          await this.redisPubClient.publish("LiquidateTrader", msg);
-          this.messageSentAt.set(msg, Date.now());
-        }
-        accountsSent.add(msg);
+      if (!this.isMarginSafe(positions.get(trader)!, curPx)) candidates.push(trader);
+    }
+    if (candidates.length === 0) return false;
+
+    await this.reconcileWatchlist();
+    if (!this.symbols.includes(symbol)) return false;
+
+    let perSymbol = this.messageSentAt.get(symbol);
+    if (!perSymbol) {
+      perSymbol = new Map();
+      this.messageSentAt.set(symbol, perSymbol);
+    }
+    for (const trader of candidates) {
+      const msg = JSON.stringify({
+        chainId: this.chainId,
+        symbol: symbol,
+        traderAddr: trader,
+      });
+      if (Date.now() - (perSymbol.get(trader) ?? 0) > this.config.liquidateIntervalSecondsMin * 1_000) {
+        await this.redisPubClient.publish("LiquidateTrader", msg);
+        perSymbol.set(trader, Date.now());
       }
+      accountsSent.add(msg);
     }
     return accountsSent.size > 0;
   }

--- a/src/executor/liquidator.ts
+++ b/src/executor/liquidator.ts
@@ -5,6 +5,7 @@ import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
 import { formatCacheAgeSuffix, initLiquidatorsFromMarketData, initMarketDataWithCache } from "../sdkInit.js";
 import { BotStatus, LiquidateTraderMsg, LiquidatorConfig } from "../types.js";
 import { constructRedis, executeWithTimeout, sleep } from "../utils.js";
+import { loadWatchlist, watchlistChannel } from "../watchlist.js";
 import { Metrics } from "./metrics.js";
 
 // Liquidation result status
@@ -38,6 +39,7 @@ export default class Liquidator {
   // Set of symbol:traderAddr elements which are currently being processed.
   private locked: Set<string> = new Set();
   private timesTried: Map<string, number> = new Map();
+  private allowedSymbols: Set<string> | null = null;
 
   protected metrics: Metrics;
 
@@ -111,14 +113,29 @@ export default class Liquidator {
     );
     await initLiquidatorsFromMarketData(this.bots, md, this.providers[result.providerIndex]);
 
+    const initial = await loadWatchlist(this.redisPubClient, this.chainId);
+    if (initial !== null) {
+      this.allowedSymbols = new Set(initial);
+      console.log({
+        info: "executor: loaded initial watchlist from redis",
+        time: new Date(Date.now()).toISOString(),
+        size: initial.length,
+      });
+    }
+
     // Subscribe to relayed events
     // console.log(`${new Date(Date.now()).toISOString()}: subscribing to account streamer...`);
-    await this.redisSubClient.subscribe("block", "LiquidateTrader", (err, count) => {
-      if (err) {
-        console.log(`${new Date(Date.now()).toISOString()}: redis subscription failed: ${err}`);
-        process.exit(1);
+    await this.redisSubClient.subscribe(
+      "block",
+      "LiquidateTrader",
+      watchlistChannel(this.chainId),
+      (err, count) => {
+        if (err) {
+          console.log(`${new Date(Date.now()).toISOString()}: redis subscription failed: ${err}`);
+          process.exit(1);
+        }
       }
-    });
+    );
     console.log("initialized");
   }
 
@@ -136,7 +153,17 @@ export default class Liquidator {
         }
       });
 
+      const watchlistCh = watchlistChannel(this.chainId);
       this.redisSubClient.on("message", async (channel, msg) => {
+        if (channel === watchlistCh) {
+          try {
+            const list = JSON.parse(msg);
+            if (Array.isArray(list)) {
+              this.allowedSymbols = new Set(list.filter((s): s is string => typeof s === "string"));
+            }
+          } catch {}
+          return;
+        }
         switch (channel) {
           case "LiquidateTrader": {
             const prevCount = this.q.size;
@@ -168,7 +195,17 @@ export default class Liquidator {
     if (this.bots[botIdx].busy || this.locked.has(`${symbol}:${trader}`)) {
       return LiquidationStatus.NoOp;
     }
-    // lock
+    if (this.allowedSymbols === null || !this.allowedSymbols.has(symbol)) {
+      console.log({
+        info: this.allowedSymbols === null
+          ? "executor: skipping - watchlist not yet received"
+          : "executor: skipping - not in watchlist",
+        time: new Date(Date.now()).toISOString(),
+        symbol,
+        trader,
+      });
+      return LiquidationStatus.NoOp;
+    }
     const id = `${symbol}:${trader}`;
     this.bots[botIdx].busy = true;
     this.locked.add(id);

--- a/src/executor/liquidator.ts
+++ b/src/executor/liquidator.ts
@@ -5,7 +5,7 @@ import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
 import { formatCacheAgeSuffix, initLiquidatorsFromMarketData, initMarketDataWithCache } from "../sdkInit.js";
 import { BotStatus, LiquidateTraderMsg, LiquidatorConfig } from "../types.js";
 import { constructRedis, executeWithTimeout, sleep } from "../utils.js";
-import { loadWatchlist, watchlistChannel } from "../watchlist.js";
+import { loadWatchlist, parsePerpStates, watchlistChannel } from "../watchlist.js";
 import { Metrics } from "./metrics.js";
 
 // Liquidation result status
@@ -115,11 +115,11 @@ export default class Liquidator {
 
     const initial = await loadWatchlist(this.redisPubClient, this.chainId);
     if (initial !== null) {
-      this.allowedSymbols = new Set(initial);
+      this.allowedSymbols = new Set(Object.keys(initial).filter((s) => initial[s] === "NORMAL"));
       console.log({
         info: "executor: loaded initial watchlist from redis",
         time: new Date(Date.now()).toISOString(),
-        size: initial.length,
+        size: this.allowedSymbols.size,
       });
     }
 
@@ -156,12 +156,10 @@ export default class Liquidator {
       const watchlistCh = watchlistChannel(this.chainId);
       this.redisSubClient.on("message", async (channel, msg) => {
         if (channel === watchlistCh) {
-          try {
-            const list = JSON.parse(msg);
-            if (Array.isArray(list)) {
-              this.allowedSymbols = new Set(list.filter((s): s is string => typeof s === "string"));
-            }
-          } catch {}
+          const states = parsePerpStates(msg);
+          if (states) {
+            this.allowedSymbols = new Set(Object.keys(states).filter((s) => states[s] === "NORMAL"));
+          }
           return;
         }
         switch (channel) {

--- a/src/sentinel/blockchainListener.ts
+++ b/src/sentinel/blockchainListener.ts
@@ -2,7 +2,13 @@ import { ABK64x64ToFloat, IPerpetualManager__factory, MarketData, PerpetualDataH
 import { Redis } from "ioredis";
 import SturdyWebSocket from "sturdy-websocket";
 import Websocket from "ws";
-import { LiquidateMsg, LiquidatorConfig, UpdateMarginAccountMsg, UpdateMarkPriceMsg } from "../types.js";
+import {
+  LiquidateMsg,
+  LiquidatorConfig,
+  PerpEmergencyMsg,
+  UpdateMarginAccountMsg,
+  UpdateMarkPriceMsg,
+} from "../types.js";
 import { constructRedis, executeWithTimeout, sleep } from "../utils.js";
 
 import { JsonRpcProvider, Network, SocketProvider, WebSocketProvider } from "ethers";
@@ -361,6 +367,24 @@ export default class BlockhainListener {
           mode: ListeningMode,
           ...msg,
         });
+      }
+    );
+
+    proxy.on(
+      proxy.filters.SetEmergencyState,
+      (perpetualId: bigint, _r: bigint, _s2: bigint, _s3: bigint, event: any) => {
+        const perpId = Number(perpetualId);
+        const symbol = this.md.getSymbolFromPerpId(perpId);
+        if (symbol === undefined) return;
+        const msg: PerpEmergencyMsg = {
+          perpetualId: perpId,
+          symbol,
+          block: event.log.blockNumber,
+          hash: event.log.transactionHash,
+          id: `${event.log.transactionHash}:${event.log.index}`,
+        };
+        this.redisPubClient.publish("PerpEmergency", JSON.stringify(msg));
+        console.log({ event: "SetEmergencyState", time: new Date().toISOString(), ...msg });
       }
     );
   }

--- a/src/sentinel/blockchainListener.ts
+++ b/src/sentinel/blockchainListener.ts
@@ -387,5 +387,19 @@ export default class BlockhainListener {
         console.log({ event: "SetEmergencyState", time: new Date().toISOString(), ...msg });
       }
     );
+
+    proxy.on(proxy.filters.SetNormalState, (perpetualId: bigint, event: any) => {
+      const perpId = Number(perpetualId);
+      this.redisPubClient.publish(
+        "PerpNormal",
+        JSON.stringify({
+          perpetualId: perpId,
+          block: event.log.blockNumber,
+          hash: event.log.transactionHash,
+          id: `${event.log.transactionHash}:${event.log.index}`,
+        })
+      );
+      console.log({ event: "SetNormalState", time: new Date().toISOString(), perpetualId: perpId });
+    });
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,10 +81,9 @@ export interface UpdateMarkPriceMsg extends RedisMsg {
   spotIndexPrice: number;
 }
 
-export interface UpdateUnitAccumulatedFundingMsg extends RedisMsg {
+export interface PerpEmergencyMsg extends RedisMsg {
   perpetualId: number;
   symbol: string;
-  unitAccumulatedFundingCC: number;
 }
 
 export interface LiquidateTraderMsg {

--- a/src/watchlist.ts
+++ b/src/watchlist.ts
@@ -2,6 +2,8 @@ import { Redis } from "ioredis";
 
 export const WATCHLIST_TTL_SECONDS = 30 * 60;
 
+export type PerpStates = Record<string, string>;
+
 export function watchlistKey(chainId: number): string {
   return `liquidator-watchlist:${chainId}`;
 }
@@ -10,18 +12,33 @@ export function watchlistChannel(chainId: number): string {
   return `liquidator-watchlist-updates:${chainId}`;
 }
 
+export function serializePerpStates(states: PerpStates): string {
+  const sortedKeys = Object.keys(states).sort();
+  const ordered: PerpStates = {};
+  for (const k of sortedKeys) ordered[k] = states[k];
+  return JSON.stringify(ordered);
+}
+
 export async function publishWatchlist(redis: Redis, chainId: number, payload: string): Promise<void> {
   await redis.set(watchlistKey(chainId), payload, "EX", WATCHLIST_TTL_SECONDS);
   await redis.publish(watchlistChannel(chainId), payload);
 }
 
-export async function loadWatchlist(redis: Redis, chainId: number): Promise<string[] | null> {
+export async function loadWatchlist(redis: Redis, chainId: number): Promise<PerpStates | null> {
   const raw = await redis.get(watchlistKey(chainId));
   if (!raw) return null;
+  return parsePerpStates(raw);
+}
+
+export function parsePerpStates(raw: string): PerpStates | null {
   try {
     const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return null;
-    return parsed.filter((s): s is string => typeof s === "string");
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    const out: PerpStates = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (typeof v === "string") out[k] = v;
+    }
+    return out;
   } catch {
     return null;
   }

--- a/src/watchlist.ts
+++ b/src/watchlist.ts
@@ -1,0 +1,28 @@
+import { Redis } from "ioredis";
+
+export const WATCHLIST_TTL_SECONDS = 30 * 60;
+
+export function watchlistKey(chainId: number): string {
+  return `liquidator-watchlist:${chainId}`;
+}
+
+export function watchlistChannel(chainId: number): string {
+  return `liquidator-watchlist-updates:${chainId}`;
+}
+
+export async function publishWatchlist(redis: Redis, chainId: number, payload: string): Promise<void> {
+  await redis.set(watchlistKey(chainId), payload, "EX", WATCHLIST_TTL_SECONDS);
+  await redis.publish(watchlistChannel(chainId), payload);
+}
+
+export async function loadWatchlist(redis: Redis, chainId: number): Promise<string[] | null> {
+  const raw = await redis.get(watchlistKey(chainId));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    return parsed.filter((s): s is string => typeof s === "string");
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #25 

Problem: 

SDK triggers refresh based on slot expiries . While games are settled before that expiry time, the liquidator would still be trying to liquidate accounts for settled games. 

Solution: 

make the liquidator listen to when perp state is no longer NORMAL and make sure the liquidator pause liquidation of that perp. At some point the SDK will refresh its perps and will overwrite that watched list. Concretely:

1. Distributor keeps this.symbols in memory and additionally publishes the live list (just the array of NORMAL symbols) to Redis whenever it changes (we check is the perps list data changed whenever we detect liquidatables and periodically).
2. Executor subscribes via Redis pub/sub. When a new list arrives, it overwrites its own in memory
copy. Before submitting a liquidation, it checks symbol $\in$ inMemoryList. if not, it skips.
