### PR TITLE
make chunk sizes configurable in LiquidatorConfig and reduce default

### DIFF
--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -439,8 +439,8 @@ export default class Distributor {
       );
       return;
     }
-    const chunkSize1 = 2 ** 16; // for addresses
-    const chunkSize2 = 2 ** 8; // for margin accounts
+    const chunkSize1 = this.config.addressChunkSize ?? 1024; // for addresses
+    const chunkSize2 = this.config.accountChunkSize ?? 128; // for margin accounts
     const perpId = this.md.getPerpIdFromSymbol(symbol)!;
     const proxy = this.md.getReadOnlyProxyInstance() as any as IPerpetualManager;
     this.lastRefreshTime.set(symbol, Date.now());

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,8 @@ export interface LiquidatorConfig {
   maxGasPriceGWei: number;
   gasLimit: number;
   priceFeedEndpoints: Array<PriceFeedEndpointsItem>;
+  addressChunkSize?: number;
+  accountChunkSize?: number;
 }
 
 export interface RedisMsg {


### PR DESCRIPTION
made configurable and reduced the default values of chunk sizes  specified by the commander's address fetch and trader state so no longer overshoot the RPC's eth_call

