### PR TITLE
Metrics

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -9,7 +9,6 @@
 #
 # And ./config/live.liquidatorConfig.json must exist (copy from
 # src/config/sample.liquidatorConfig.json and add a base_sepolia entry).
-#
 # Run:
 #   docker compose -f docker-compose.local.yml up --build -d
 
@@ -47,6 +46,8 @@ services:
       REDIS_ID: 4
       SDK_CONFIG: base_sepolia
       LIQUIDATOR_CONFIG_PATH: /etc/liquidatorconf.json
+    volumes:
+      - /Users/souhailaserbout/git/d8x-node-sdk:/app/node_modules/@d8-x/d8x-node-sdk:ro
     configs:
       - source: liquidator_config
         target: /etc/liquidatorconf.json
@@ -73,6 +74,11 @@ services:
       REDIS_ID: 4
       SDK_CONFIG: base_sepolia
       LIQUIDATOR_CONFIG_PATH: /etc/liquidatorconf.json
+      METRICS_PORT: "9011"
+    ports:
+      - "127.0.0.1:9011:9011"
+    volumes:
+      - /Users/souhailaserbout/git/d8x-node-sdk:/app/node_modules/@d8-x/d8x-node-sdk:ro
     configs:
       - source: liquidator_config
         target: /etc/liquidatorconf.json
@@ -104,6 +110,8 @@ services:
       LIQUIDATOR_CONFIG_PATH: /etc/liquidatorconf.json
     ports:
       - "127.0.0.1:9001:9001"
+    volumes:
+      - /Users/souhailaserbout/git/d8x-node-sdk:/app/node_modules/@d8-x/d8x-node-sdk:ro
     configs:
       - source: liquidator_config
         target: /etc/liquidatorconf.json
@@ -132,8 +140,26 @@ services:
         target: /etc/prometheus/rules/liquidator.rules.yaml
     restart: unless-stopped
 
+  grafana:
+    image: grafana/grafana-oss:11.6.0
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/etc/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+
 volumes:
   prometheus_data:
+  grafana_data:
 
 configs:
   prometheus_yaml:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
         max-file: "10"
 
   commander-base:
-    image: ghcr.io/d8-x/liquidator-commander:dev
+    image: ghcr.io/d8-x/liquidator-commander:dev  # <--- we need to properly start pulling main for prod
     depends_on:
       cache:
         condition: service_healthy
@@ -200,8 +200,6 @@ services:
       - source: alertmanager_yaml
         target: /etc/alertmanager/alertmanager.yml
 
-  # Grafana co-located with the liquidator. Bound to loopback only - put
-  # nginx/Caddy in front of port 3000 with TLS + admin auth before exposing.
   grafana:
     image: grafana/grafana-oss:11.6.0
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-# sudo docker compose up --build -d
 name: d8x
 
 services:
-  # Redis for Pub/Sub between blockchain listener (pub) and liquidators (sub)
   cache:
     image: redis:6.2-alpine
     restart: always
@@ -19,7 +17,7 @@ services:
       start_period: 5s
 
   sentinel-base_sepolia:
-    image: ghcr.io/d8-x/liquidator-sentinel:main
+    image: ghcr.io/d8-x/liquidator-sentinel:dev
     #build:
     #  context: .
     #  dockerfile: ./src/sentinel/Dockerfile
@@ -44,7 +42,7 @@ services:
         max-file: "10"
 
   commander-base_sepolia:
-    image: ghcr.io/d8-x/liquidator-commander:main
+    image: ghcr.io/d8-x/liquidator-commander:dev
     depends_on:
       cache:
         condition: service_healthy
@@ -58,6 +56,7 @@ services:
       REDIS_ID: 4
       SDK_CONFIG: base_sepolia
       LIQUIDATOR_CONFIG_PATH: /etc/liquidatorconf.json
+      METRICS_PORT: "9011"
     configs:
       - source: liquidator_config
         target: /etc/liquidatorconf.json
@@ -69,7 +68,7 @@ services:
         max-file: "10"
 
   executor-base_sepolia:
-    image: ghcr.io/d8-x/liquidator-executor:main
+    image: ghcr.io/d8-x/liquidator-executor:dev
     depends_on:
       cache:
         condition: service_healthy
@@ -97,7 +96,7 @@ services:
         max-file: "10"
 
   sentinel-base:
-    image: ghcr.io/d8-x/liquidator-sentinel:main
+    image: ghcr.io/d8-x/liquidator-sentinel:dev
     depends_on:
       cache:
         condition: service_healthy
@@ -119,7 +118,7 @@ services:
         max-file: "10"
 
   commander-base:
-    image: ghcr.io/d8-x/liquidator-commander:main
+    image: ghcr.io/d8-x/liquidator-commander:dev
     depends_on:
       cache:
         condition: service_healthy
@@ -130,6 +129,7 @@ services:
       REDIS_ID: 5
       SDK_CONFIG: base
       LIQUIDATOR_CONFIG_PATH: /etc/liquidatorconf.json
+      METRICS_PORT: "9011"
     configs:
       - source: liquidator_config
         target: /etc/liquidatorconf.json
@@ -141,7 +141,7 @@ services:
         max-file: "10"
 
   executor-base:
-    image: ghcr.io/d8-x/liquidator-executor:main
+    image: ghcr.io/d8-x/liquidator-executor:dev
     depends_on:
       cache:
         condition: service_healthy
@@ -200,8 +200,34 @@ services:
       - source: alertmanager_yaml
         target: /etc/alertmanager/alertmanager.yml
 
+  # Grafana co-located with the liquidator. Bound to loopback only - put
+  # nginx/Caddy in front of port 3000 with TLS + admin auth before exposing.
+  grafana:
+    image: grafana/grafana-oss:11.6.0
+    restart: always
+    depends_on:
+      - prometheus
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GF_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_ADMIN_PASSWORD}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+      GF_SERVER_ROOT_URL: ${GF_SERVER_ROOT_URL:-}
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/etc/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100k"
+        max-file: "10"
+
 volumes:
   prometheus_data:
+  grafana_data:
 configs:
   prometheus_yaml:
     file: ./prometheus_configs/prometheus.yaml

--- a/grafana/dashboards/liquidators-base.json
+++ b/grafana/dashboards/liquidators-base.json
@@ -1,6 +1,6 @@
 {
-  "uid": "d8x-liquidators",
-  "title": "[${D8X_CHAIN}] Liquidators",
+  "uid": "d8x-liquidators-base",
+  "title": "Liquidators (base)",
   "description": "Operational dashboard for the d8x liquidator service.",
   "tags": [
     "d8x",
@@ -33,7 +33,7 @@
       "transparent": true,
       "options": {
         "mode": "html",
-        "content": "<div style=\"display:flex;align-items:baseline;gap:10px;padding:14px;line-height:1.4;\"><span style=\"font-size:18px;font-weight:600;letter-spacing:0.3px;\">Liquidators</span><code style=\"background:rgba(255,255,255,0.08);padding:2px 10px;border-radius:4px;font-size:13px;\">${D8X_CHAIN}</code></div>"
+        "content": "<div style=\"display:flex;align-items:baseline;gap:10px;padding:14px;line-height:1.4;\"><span style=\"font-size:18px;font-weight:600;letter-spacing:0.3px;\">Liquidators</span><code style=\"background:rgba(255,255,255,0.08);padding:2px 10px;border-radius:4px;font-size:13px;\">base</code></div>"
       }
     },
     {
@@ -91,7 +91,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "sum(increase(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=\"confirmed\"}[$__range])) or vector(0)",
+          "expr": "sum(increase(liquidator_liquidations_total{chain=\"base\", outcome=\"confirmed\"}[$__range])) or vector(0)",
           "legendFormat": "confirmed"
         }
       ]
@@ -154,7 +154,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "sum(increase(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=\"failed\"}[$__range])) or vector(0)",
+          "expr": "sum(increase(liquidator_liquidations_total{chain=\"base\", outcome=\"failed\"}[$__range])) or vector(0)",
           "legendFormat": "failed"
         }
       ]
@@ -217,7 +217,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "sum(increase(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=\"rejected\"}[$__range])) or vector(0)",
+          "expr": "sum(increase(liquidator_liquidations_total{chain=\"base\", outcome=\"rejected\"}[$__range])) or vector(0)",
           "legendFormat": "rejected"
         }
       ]
@@ -283,7 +283,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "min(liquidator_min_balance_eth{chain=\"${D8X_CHAIN}\"})",
+          "expr": "min(liquidator_min_balance_eth{chain=\"base\"})",
           "legendFormat": "min",
           "instant": true,
           "format": "time_series"
@@ -296,7 +296,7 @@
       "title": "Throughput",
       "gridPos": {
         "x": 0,
-        "y": 29,
+        "y": 42,
         "w": 24,
         "h": 1
       },
@@ -312,7 +312,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 30
+        "y": 43
       },
       "datasource": {
         "uid": "d8x-prom",
@@ -402,7 +402,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "sum by (outcome) (rate(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\"}[$__rate_interval]))",
+          "expr": "sum by (outcome) (rate(liquidator_liquidations_total{chain=\"base\"}[$__rate_interval]))",
           "legendFormat": "{{outcome}}"
         }
       ]
@@ -416,7 +416,7 @@
         "h": 12,
         "w": 12,
         "x": 12,
-        "y": 30
+        "y": 43
       },
       "datasource": {
         "uid": "d8x-prom",
@@ -461,7 +461,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "topk(10, sum by (symbol) (increase(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=\"confirmed\"}[$__range])))",
+          "expr": "topk(10, sum by (symbol) (increase(liquidator_liquidations_total{chain=\"base\", outcome=\"confirmed\"}[$__range])))",
           "format": "time_series",
           "instant": true,
           "legendFormat": "{{symbol}}"
@@ -474,7 +474,7 @@
       "title": "Failures by Reason",
       "gridPos": {
         "x": 0,
-        "y": 42,
+        "y": 55,
         "w": 24,
         "h": 1
       },
@@ -489,7 +489,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 43
+        "y": 56
       },
       "datasource": {
         "uid": "d8x-prom",
@@ -530,7 +530,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "sum by (outcome, reason) (rate(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=~\"failed|rejected\"}[$__rate_interval]))",
+          "expr": "sum by (outcome, reason) (rate(liquidator_liquidations_total{chain=\"base\", outcome=~\"failed|rejected\"}[$__rate_interval]))",
           "legendFormat": "{{outcome}}/{{reason}}"
         }
       ]
@@ -543,7 +543,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 43
+        "y": 56
       },
       "datasource": {
         "uid": "d8x-prom",
@@ -568,7 +568,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "topk(10, sum by (symbol, outcome, reason) (increase(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=~\"failed|rejected\"}[$__range])))",
+          "expr": "topk(10, sum by (symbol, outcome, reason) (increase(liquidator_liquidations_total{chain=\"base\", outcome=~\"failed|rejected\"}[$__range])))",
           "format": "table",
           "instant": true
         }
@@ -746,7 +746,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "liquidator_bot_info{chain=\"${D8X_CHAIN}\", bot_addr!=\"\"}",
+          "expr": "liquidator_bot_info{chain=\"base\", bot_addr!=\"\"}",
           "format": "table",
           "instant": true
         },
@@ -756,7 +756,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "liquidator_bot_balance_eth{chain=\"${D8X_CHAIN}\"}",
+          "expr": "liquidator_bot_balance_eth{chain=\"base\"}",
           "format": "table",
           "instant": true
         },
@@ -766,7 +766,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "time() - liquidator_last_liquidation_timestamp_seconds{chain=\"${D8X_CHAIN}\"}",
+          "expr": "time() - liquidator_last_liquidation_timestamp_seconds{chain=\"base\"}",
           "format": "table",
           "instant": true
         },
@@ -776,7 +776,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "sum by (bot_idx) (increase(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=\"confirmed\"}[$__range]))",
+          "expr": "sum by (bot_idx) (increase(liquidator_liquidations_total{chain=\"base\", outcome=\"confirmed\"}[$__range]))",
           "format": "table",
           "instant": true
         },
@@ -786,7 +786,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "sum by (bot_idx) (increase(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=\"failed\"}[$__range]))",
+          "expr": "sum by (bot_idx) (increase(liquidator_liquidations_total{chain=\"base\", outcome=\"failed\"}[$__range]))",
           "format": "table",
           "instant": true
         },
@@ -796,7 +796,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "sum by (bot_idx) (increase(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=\"rejected\"}[$__range]))",
+          "expr": "sum by (bot_idx) (increase(liquidator_liquidations_total{chain=\"base\", outcome=\"rejected\"}[$__range]))",
           "format": "table",
           "instant": true
         },
@@ -806,7 +806,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "sum by (bot_idx) (increase(liquidator_funding_failures_total{chain=\"${D8X_CHAIN}\"}[$__range]))",
+          "expr": "sum by (bot_idx) (increase(liquidator_funding_failures_total{chain=\"base\"}[$__range]))",
           "format": "table",
           "instant": true
         },
@@ -816,7 +816,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "sum by (bot_idx) (increase(liquidator_gas_spent_wei_total{chain=\"${D8X_CHAIN}\"}[$__range])) / 1e18",
+          "expr": "sum by (bot_idx) (increase(liquidator_gas_spent_wei_total{chain=\"base\"}[$__range])) / 1e18",
           "format": "table",
           "instant": true
         }
@@ -869,7 +869,7 @@
       "title": "Funding",
       "gridPos": {
         "x": 0,
-        "y": 51,
+        "y": 64,
         "w": 24,
         "h": 1
       },
@@ -884,7 +884,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 65
       },
       "datasource": {
         "uid": "d8x-prom",
@@ -921,7 +921,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "sum by (reason) (rate(liquidator_funding_failures_total{chain=\"${D8X_CHAIN}\"}[$__rate_interval]))",
+          "expr": "sum by (reason) (rate(liquidator_funding_failures_total{chain=\"base\"}[$__rate_interval]))",
           "legendFormat": "{{reason}}"
         }
       ]
@@ -1000,7 +1000,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "time() - max(liquidator_last_pool_check_seconds{chain=\"${D8X_CHAIN}\", status=\"ok\"})",
+          "expr": "time() - max(liquidator_last_pool_check_seconds{chain=\"base\", status=\"ok\"})",
           "legendFormat": "_",
           "instant": true
         }
@@ -1051,7 +1051,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "sum(increase(liquidator_pool_checks_total{chain=\"${D8X_CHAIN}\"}[$__range]))",
+          "expr": "sum(increase(liquidator_pool_checks_total{chain=\"base\"}[$__range]))",
           "legendFormat": "_",
           "instant": true
         }
@@ -1118,7 +1118,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "sum(liquidator_last_pool_liquidatable_count{chain=\"${D8X_CHAIN}\"})",
+          "expr": "sum(liquidator_last_pool_liquidatable_count{chain=\"base\"})",
           "legendFormat": "_",
           "instant": true
         }
@@ -1182,7 +1182,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "liquidator_config_gas_limit{chain=\"${D8X_CHAIN}\"}",
+          "expr": "liquidator_config_gas_limit{chain=\"base\"}",
           "legendFormat": "_",
           "instant": true
         }
@@ -1233,7 +1233,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "liquidator_config_gas_price_multiplier{chain=\"${D8X_CHAIN}\"}",
+          "expr": "liquidator_config_gas_price_multiplier{chain=\"base\"}",
           "legendFormat": "_",
           "instant": true
         }
@@ -1284,7 +1284,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "liquidator_config_bots{chain=\"${D8X_CHAIN}\"}",
+          "expr": "liquidator_config_bots{chain=\"base\"}",
           "legendFormat": "_",
           "instant": true
         }
@@ -1336,7 +1336,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "liquidator_config_liquidate_interval_seconds_min{chain=\"${D8X_CHAIN}\"}",
+          "expr": "liquidator_config_liquidate_interval_seconds_min{chain=\"base\"}",
           "legendFormat": "_",
           "instant": true
         }
@@ -1388,7 +1388,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "liquidator_config_liquidate_interval_seconds_max{chain=\"${D8X_CHAIN}\"}",
+          "expr": "liquidator_config_liquidate_interval_seconds_max{chain=\"base\"}",
           "legendFormat": "_",
           "instant": true
         }
@@ -1440,7 +1440,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "liquidator_config_fetch_prices_interval_seconds_min{chain=\"${D8X_CHAIN}\"}",
+          "expr": "liquidator_config_fetch_prices_interval_seconds_min{chain=\"base\"}",
           "legendFormat": "_",
           "instant": true
         }
@@ -1508,7 +1508,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "liquidator_treasury_balance_eth{chain=\"${D8X_CHAIN}\"}",
+          "expr": "liquidator_treasury_balance_eth{chain=\"base\"}",
           "legendFormat": "_",
           "instant": true,
           "format": "time_series"
@@ -1559,7 +1559,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "liquidator_config_check_interval_seconds_min{chain=\"${D8X_CHAIN}\"}",
+          "expr": "liquidator_config_check_interval_seconds_min{chain=\"base\"}",
           "legendFormat": "_",
           "instant": true
         }
@@ -1609,7 +1609,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "liquidator_config_check_interval_seconds_max{chain=\"${D8X_CHAIN}\"}",
+          "expr": "liquidator_config_check_interval_seconds_max{chain=\"base\"}",
           "legendFormat": "_",
           "instant": true
         }
@@ -1658,7 +1658,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "liquidator_config_liquidatable_batch_size{chain=\"${D8X_CHAIN}\"}",
+          "expr": "liquidator_config_liquidatable_batch_size{chain=\"base\"}",
           "legendFormat": "_",
           "instant": true
         }
@@ -1708,7 +1708,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "liquidator_config_price_move_pct_threshold{chain=\"${D8X_CHAIN}\"}",
+          "expr": "liquidator_config_price_move_pct_threshold{chain=\"base\"}",
           "legendFormat": "_",
           "instant": true
         }
@@ -1720,7 +1720,7 @@
       "title": "Gas",
       "gridPos": {
         "x": 0,
-        "y": 60,
+        "y": 29,
         "w": 24,
         "h": 1
       },
@@ -1733,10 +1733,10 @@
       "description": "Total native-token spent by the bot fleet on confirmed transactions, all-time. Sum of liquidator_gas_spent_wei_total / 1e18.",
       "type": "stat",
       "gridPos": {
-        "h": 4,
-        "w": 8,
         "x": 0,
-        "y": 61
+        "y": 30,
+        "w": 8,
+        "h": 4
       },
       "datasource": {
         "uid": "d8x-prom",
@@ -1772,7 +1772,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "sum(liquidator_gas_spent_wei_total{chain=\"${D8X_CHAIN}\"}) / 1e18",
+          "expr": "sum(liquidator_gas_spent_wei_total{chain=\"base\"}) / 1e18",
           "instant": true,
           "format": "time_series",
           "legendFormat": "_"
@@ -1785,10 +1785,10 @@
       "description": "Native-token spent on confirmed transactions in the last 24 hours. increase(liquidator_gas_spent_wei_total[24h]) / 1e18.",
       "type": "stat",
       "gridPos": {
-        "h": 4,
-        "w": 8,
         "x": 8,
-        "y": 61
+        "y": 30,
+        "w": 8,
+        "h": 4
       },
       "datasource": {
         "uid": "d8x-prom",
@@ -1824,7 +1824,7 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "sum(increase(liquidator_gas_spent_wei_total{chain=\"${D8X_CHAIN}\"}[24h])) / 1e18",
+          "expr": "sum(increase(liquidator_gas_spent_wei_total{chain=\"base\"}[24h])) / 1e18",
           "instant": true,
           "format": "time_series",
           "legendFormat": "_"
@@ -1837,10 +1837,10 @@
       "description": "Native-token spent per bot wallet over the dashboard time range.",
       "type": "bargauge",
       "gridPos": {
-        "h": 4,
-        "w": 8,
         "x": 16,
-        "y": 61
+        "y": 30,
+        "w": 8,
+        "h": 4
       },
       "datasource": {
         "uid": "d8x-prom",
@@ -1851,8 +1851,10 @@
           "decimals": 6,
           "unit": "ETH",
           "color": {
-            "mode": "continuous-YlOr"
-          }
+            "mode": "continuous-YlRd"
+          },
+          "noValue": "0",
+          "min": 0
         }
       },
       "options": {
@@ -1865,6 +1867,62 @@
             "lastNotNull"
           ],
           "values": false
+        },
+        "minVizHeight": 16
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "(sum by (bot_idx) (increase(liquidator_gas_spent_wei_total{chain=\"base\"}[$__range])) / 1e18) or label_replace(vector(0), \"bot_idx\", \"0\", \"\", \"\")",
+          "instant": true,
+          "format": "time_series",
+          "legendFormat": "bot {{bot_idx}}"
+        }
+      ]
+    },
+    {
+      "id": 184,
+      "title": "Treasury balance over time",
+      "description": "Native-token balance of the treasury wallet over time (gauge sample). liquidator_treasury_balance_eth.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 6,
+          "unit": "ETH",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "orange"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -1874,10 +1932,61 @@
             "uid": "d8x-prom",
             "type": "prometheus"
           },
-          "expr": "sum by (bot_idx) (increase(liquidator_gas_spent_wei_total{chain=\"${D8X_CHAIN}\"}[$__range])) / 1e18",
-          "instant": true,
-          "format": "time_series",
-          "legendFormat": "bot {{bot_idx}}"
+          "expr": "liquidator_treasury_balance_eth{chain=\"base\"}",
+          "legendFormat": "treasury"
+        }
+      ]
+    },
+    {
+      "id": 185,
+      "title": "Gas spent (cumulative) over time",
+      "description": "Cumulative gas spent (ETH) by the bot fleet over time. sum(liquidator_gas_spent_wei_total) / 1e18.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 6,
+          "unit": "ETH",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "yellow"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum(liquidator_gas_spent_wei_total{chain=\"base\"}) / 1e18",
+          "legendFormat": "gas spent"
         }
       ]
     }

--- a/grafana/dashboards/liquidators-base_sepolia.json
+++ b/grafana/dashboards/liquidators-base_sepolia.json
@@ -1,0 +1,1997 @@
+{
+  "uid": "d8x-liquidators-base_sepolia",
+  "title": "Liquidators (base_sepolia)",
+  "description": "Operational dashboard for the d8x liquidator service.",
+  "tags": [
+    "d8x",
+    "ops",
+    "liquidators"
+  ],
+  "timezone": "utc",
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "templating": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "text",
+      "title": "",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 2
+      },
+      "transparent": true,
+      "options": {
+        "mode": "html",
+        "content": "<div style=\"display:flex;align-items:baseline;gap:10px;padding:14px;line-height:1.4;\"><span style=\"font-size:18px;font-weight:600;letter-spacing:0.3px;\">Liquidators</span><code style=\"background:rgba(255,255,255,0.08);padding:2px 10px;border-radius:4px;font-size:13px;\">base_sepolia</code></div>"
+      }
+    },
+    {
+      "id": 100,
+      "type": "row",
+      "title": "Status",
+      "gridPos": {
+        "x": 0,
+        "y": 2,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 101,
+      "title": "Confirmed liquidations",
+      "description": "Liquidation transactions accepted on-chain in the selected time range. Counted from liquidator_liquidations_total{outcome=\"confirmed\"}.",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 3,
+        "w": 5,
+        "h": 4
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "green"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(liquidator_liquidations_total{chain=\"base_sepolia\", outcome=\"confirmed\"}[$__range])) or vector(0)",
+          "legendFormat": "confirmed"
+        }
+      ]
+    },
+    {
+      "id": 102,
+      "title": "Failed",
+      "description": "Liquidations submitted but reverted on-chain in the selected time range. High values usually mean RPC/gas issues. liquidator_liquidations_total{outcome=\"failed\"}.",
+      "type": "stat",
+      "gridPos": {
+        "x": 5,
+        "y": 3,
+        "w": 5,
+        "h": 4
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(liquidator_liquidations_total{chain=\"base_sepolia\", outcome=\"failed\"}[$__range])) or vector(0)",
+          "legendFormat": "failed"
+        }
+      ]
+    },
+    {
+      "id": 103,
+      "title": "Rejected",
+      "description": "Liquidation candidates the bot decided not to send (e.g. trader became margin-safe between detection and submit) in the selected time range. liquidator_liquidations_total{outcome=\"rejected\"}.",
+      "type": "stat",
+      "gridPos": {
+        "x": 10,
+        "y": 3,
+        "w": 5,
+        "h": 4
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(liquidator_liquidations_total{chain=\"base_sepolia\", outcome=\"rejected\"}[$__range])) or vector(0)",
+          "legendFormat": "rejected"
+        }
+      ]
+    },
+    {
+      "id": 104,
+      "title": "Min Bot Balance",
+      "description": "Lowest configured min-balance threshold across the bot fleet (from liquidator_min_balance_eth).",
+      "type": "stat",
+      "gridPos": {
+        "x": 15,
+        "y": 3,
+        "w": 4,
+        "h": 4
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 6,
+          "unit": "ETH",
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.005
+              },
+              {
+                "color": "green",
+                "value": 0.02
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "min(liquidator_min_balance_eth{chain=\"base_sepolia\"})",
+          "legendFormat": "min",
+          "instant": true,
+          "format": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 110,
+      "type": "row",
+      "title": "Throughput",
+      "gridPos": {
+        "x": 0,
+        "y": 42,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 111,
+      "title": "Liquidation rate, by outcome",
+      "description": "Per-second rate of liquidation attempts split by outcome over the last 5 minutes. Confirmed = on-chain success, Failed = tx reverted, Rejected = aborted before submit.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "stacking": {
+              "mode": "none"
+            },
+            "showPoints": "never",
+            "lineWidth": 2
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "confirmed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "rejected"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "sum",
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (outcome) (rate(liquidator_liquidations_total{chain=\"base_sepolia\"}[$__rate_interval]))",
+          "legendFormat": "{{outcome}}"
+        }
+      ]
+    },
+    {
+      "id": 112,
+      "title": "Top 10 symbols",
+      "description": "Symbols with the most liquidation events in the last hour, broken down by outcome. Tells you where the bot is doing real work.",
+      "type": "bargauge",
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "valueMode": "color",
+        "showUnfilled": true,
+        "minVizWidth": 0,
+        "minVizHeight": 16,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "topk(10, sum by (symbol) (increase(liquidator_liquidations_total{chain=\"base_sepolia\", outcome=\"confirmed\"}[$__range])))",
+          "format": "time_series",
+          "instant": true,
+          "legendFormat": "{{symbol}}"
+        }
+      ]
+    },
+    {
+      "id": 120,
+      "type": "row",
+      "title": "Failures by Reason",
+      "gridPos": {
+        "x": 0,
+        "y": 55,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 121,
+      "title": "Failed + Rejected rate, by reason",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 56
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (outcome, reason) (rate(liquidator_liquidations_total{chain=\"base_sepolia\", outcome=~\"failed|rejected\"}[$__rate_interval]))",
+          "legendFormat": "{{outcome}}/{{reason}}"
+        }
+      ]
+    },
+    {
+      "id": 122,
+      "title": "Top reasons (in time range)",
+      "type": "table",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 56
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "custom": {
+            "align": "left",
+            "filterable": true
+          }
+        }
+      },
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "topk(10, sum by (symbol, outcome, reason) (increase(liquidator_liquidations_total{chain=\"base_sepolia\", outcome=~\"failed|rejected\"}[$__range])))",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "renameByName": {
+              "Value": "Count (1h)"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Count (1h)",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": 130,
+      "type": "row",
+      "title": "Bot Fleet",
+      "gridPos": {
+        "x": 0,
+        "y": 20,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 131,
+      "title": "Per-bot status",
+      "description": "One row per bot. Confirmed / Failed / Rejected / Funding failures counted over the selected time range; Idle for is time since last successful liquidation.",
+      "type": "table",
+      "gridPos": {
+        "x": 0,
+        "y": 21,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 4,
+          "noValue": "no data",
+          "custom": {
+            "align": "right",
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Balance (ETH)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ETH"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 0.005
+                    },
+                    {
+                      "color": "green",
+                      "value": 0.02
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Idle for (s)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 1800
+                    },
+                    {
+                      "color": "red",
+                      "value": 7200
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Address"
+            },
+            "properties": [
+              {
+                "id": "custom.minWidth",
+                "value": 380
+              },
+              {
+                "id": "custom.width",
+                "value": 380
+              },
+              {
+                "id": "custom.align",
+                "value": "left"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_bot_info{chain=\"base_sepolia\", bot_addr!=\"\"}",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_bot_balance_eth{chain=\"base_sepolia\"}",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "time() - liquidator_last_liquidation_timestamp_seconds{chain=\"base_sepolia\"}",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (bot_idx) (increase(liquidator_liquidations_total{chain=\"base_sepolia\", outcome=\"confirmed\"}[$__range]))",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "E",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (bot_idx) (increase(liquidator_liquidations_total{chain=\"base_sepolia\", outcome=\"failed\"}[$__range]))",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "F",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (bot_idx) (increase(liquidator_liquidations_total{chain=\"base_sepolia\", outcome=\"rejected\"}[$__range]))",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "G",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (bot_idx) (increase(liquidator_funding_failures_total{chain=\"base_sepolia\"}[$__range]))",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "H",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (bot_idx) (increase(liquidator_gas_spent_wei_total{chain=\"base_sepolia\"}[$__range])) / 1e18",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true,
+              "chain": true,
+              "Value #A": true
+            },
+            "indexByName": {
+              "bot_idx": 0,
+              "bot_addr": 1,
+              "Value #B": 2,
+              "Value #C": 3,
+              "Value #D": 4,
+              "Value #E": 5,
+              "Value #F": 6,
+              "Value #G": 7,
+              "Value #H": 8
+            },
+            "renameByName": {
+              "bot_idx": "Bot",
+              "bot_addr": "Address",
+              "Value #B": "Balance (ETH)",
+              "Value #C": "Idle for (s)",
+              "Value #D": "Confirmed",
+              "Value #E": "Failed",
+              "Value #F": "Rejected",
+              "Value #G": "Funding failures",
+              "Value #H": "Gas spent (ETH)"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 140,
+      "type": "row",
+      "title": "Funding",
+      "gridPos": {
+        "x": 0,
+        "y": 64,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 141,
+      "title": "Funding failures rate, by reason",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 65
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (reason) (rate(liquidator_funding_failures_total{chain=\"base_sepolia\"}[$__rate_interval]))",
+          "legendFormat": "{{reason}}"
+        }
+      ]
+    },
+    {
+      "id": 150,
+      "type": "row",
+      "title": "Liquidator activity",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 7,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 151,
+      "title": "Last pool check (sec ago)",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "never",
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "time() - max(liquidator_last_pool_check_seconds{chain=\"base_sepolia\", status=\"ok\"})",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "Seconds since the last successful getLiquidatableAccountsInPool call. Value lags actual activity by up to one Prometheus scrape interval (currently 30s) -- a 'fresh' check can show as up to ~30s ago even when the commander is healthy. To reduce wobble, lower scrape_interval in prometheus.yaml."
+    },
+    {
+      "id": 152,
+      "title": "Pool checks (in time range)",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(liquidator_pool_checks_total{chain=\"base_sepolia\"}[$__range]))",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "Total getLiquidatableAccountsInPool calls (ok + failed) in the selected time range."
+    },
+    {
+      "id": 153,
+      "title": "Currently liquidatable",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum(liquidator_last_pool_liquidatable_count{chain=\"base_sepolia\"})",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "Trader count returned by the latest pool check. Drops back to 0 after liquidation attempts complete."
+    },
+    {
+      "id": 160,
+      "type": "row",
+      "title": "Config",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 11,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 161,
+      "title": "Gas limit",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 12
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_gas_limit{chain=\"base_sepolia\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "From live.liquidatorConfig.json. Metric: liquidator_config_gas_limit"
+    },
+    {
+      "id": 163,
+      "title": "Gas multiplier",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 12
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "noValue": "0",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_gas_price_multiplier{chain=\"base_sepolia\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "From live.liquidatorConfig.json. Metric: liquidator_config_gas_price_multiplier"
+    },
+    {
+      "id": 164,
+      "title": "Bots",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 12
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_bots{chain=\"base_sepolia\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "From live.liquidatorConfig.json. Metric: liquidator_config_bots"
+    },
+    {
+      "id": 165,
+      "title": "Liquidate min (s)",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 12
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "unit": "s",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_liquidate_interval_seconds_min{chain=\"base_sepolia\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "From live.liquidatorConfig.json. Metric: liquidator_config_liquidate_interval_seconds_min"
+    },
+    {
+      "id": 166,
+      "title": "Liquidate max (s)",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 12
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "unit": "s",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_liquidate_interval_seconds_max{chain=\"base_sepolia\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "From live.liquidatorConfig.json. Metric: liquidator_config_liquidate_interval_seconds_max"
+    },
+    {
+      "id": 167,
+      "title": "Fetch prices min (s)",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 12
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "unit": "s",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_fetch_prices_interval_seconds_min{chain=\"base_sepolia\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "From live.liquidatorConfig.json. Metric: liquidator_config_fetch_prices_interval_seconds_min"
+    },
+    {
+      "id": 105,
+      "title": "Treasury balance",
+      "description": "ETH balance of the treasury wallet (HD index 0). Funds the bot wallets when they run low. Metric: liquidator_treasury_balance_eth.",
+      "type": "stat",
+      "gridPos": {
+        "x": 19,
+        "y": 3,
+        "w": 5,
+        "h": 4
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 6,
+          "unit": "ETH",
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.01
+              },
+              {
+                "color": "green",
+                "value": 0.05
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_treasury_balance_eth{chain=\"base_sepolia\"}",
+          "legendFormat": "_",
+          "instant": true,
+          "format": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 168,
+      "title": "Check min (s)",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 16
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "no data",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          },
+          "unit": "s"
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_check_interval_seconds_min{chain=\"base_sepolia\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 169,
+      "title": "Check max (s)",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 16
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "no data",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          },
+          "unit": "s"
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_check_interval_seconds_max{chain=\"base_sepolia\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 170,
+      "title": "Liquidatable batch",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 16
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "no data",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_liquidatable_batch_size{chain=\"base_sepolia\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 171,
+      "title": "Price move threshold",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 16
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "noValue": "no data",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          },
+          "unit": "percentunit"
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_price_move_pct_threshold{chain=\"base_sepolia\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 180,
+      "type": "row",
+      "title": "Gas",
+      "gridPos": {
+        "x": 0,
+        "y": 29,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 181,
+      "title": "Gas spent (cumulative)",
+      "description": "Total native-token spent by the bot fleet on confirmed transactions, all-time. Sum of liquidator_gas_spent_wei_total / 1e18.",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 30,
+        "w": 8,
+        "h": 4
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 6,
+          "unit": "ETH",
+          "noValue": "0",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "orange"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum(liquidator_gas_spent_wei_total{chain=\"base_sepolia\"}) / 1e18",
+          "instant": true,
+          "format": "time_series",
+          "legendFormat": "_"
+        }
+      ]
+    },
+    {
+      "id": 182,
+      "title": "Gas spent (last 24h)",
+      "description": "Native-token spent on confirmed transactions in the last 24 hours. increase(liquidator_gas_spent_wei_total[24h]) / 1e18.",
+      "type": "stat",
+      "gridPos": {
+        "x": 8,
+        "y": 30,
+        "w": 8,
+        "h": 4
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 6,
+          "unit": "ETH",
+          "noValue": "0",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "yellow"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(liquidator_gas_spent_wei_total{chain=\"base_sepolia\"}[24h])) / 1e18",
+          "instant": true,
+          "format": "time_series",
+          "legendFormat": "_"
+        }
+      ]
+    },
+    {
+      "id": 183,
+      "title": "Gas spent per bot (in time range)",
+      "description": "Native-token spent per bot wallet over the dashboard time range.",
+      "type": "bargauge",
+      "gridPos": {
+        "x": 16,
+        "y": 30,
+        "w": 8,
+        "h": 4
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 6,
+          "unit": "ETH",
+          "color": {
+            "mode": "continuous-YlRd"
+          },
+          "noValue": "0",
+          "min": 0
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "valueMode": "color",
+        "showUnfilled": true,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        },
+        "minVizHeight": 16
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "(sum by (bot_idx) (increase(liquidator_gas_spent_wei_total{chain=\"base_sepolia\"}[$__range])) / 1e18) or label_replace(vector(0), \"bot_idx\", \"0\", \"\", \"\")",
+          "instant": true,
+          "format": "time_series",
+          "legendFormat": "bot {{bot_idx}}"
+        }
+      ]
+    },
+    {
+      "id": 184,
+      "title": "Treasury balance over time",
+      "description": "Native-token balance of the treasury wallet over time (gauge sample). liquidator_treasury_balance_eth.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 6,
+          "unit": "ETH",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "orange"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_treasury_balance_eth{chain=\"base_sepolia\"}",
+          "legendFormat": "treasury"
+        }
+      ]
+    },
+    {
+      "id": 185,
+      "title": "Gas spent (cumulative) over time",
+      "description": "Cumulative gas spent (ETH) by the bot fleet over time. sum(liquidator_gas_spent_wei_total) / 1e18.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 6,
+          "unit": "ETH",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "yellow"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum(liquidator_gas_spent_wei_total{chain=\"base_sepolia\"}) / 1e18",
+          "legendFormat": "gas spent"
+        }
+      ]
+    }
+  ],
+  "timepicker": {
+    "hidden": false
+  }
+}

--- a/grafana/dashboards/liquidators.json
+++ b/grafana/dashboards/liquidators.json
@@ -1,0 +1,1888 @@
+{
+  "uid": "d8x-liquidators",
+  "title": "[${D8X_CHAIN}] Liquidators",
+  "description": "Operational dashboard for the d8x liquidator service.",
+  "tags": [
+    "d8x",
+    "ops",
+    "liquidators"
+  ],
+  "timezone": "utc",
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "templating": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "text",
+      "title": "",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 2
+      },
+      "transparent": true,
+      "options": {
+        "mode": "html",
+        "content": "<div style=\"display:flex;align-items:baseline;gap:10px;padding:14px;line-height:1.4;\"><span style=\"font-size:18px;font-weight:600;letter-spacing:0.3px;\">Liquidators</span><code style=\"background:rgba(255,255,255,0.08);padding:2px 10px;border-radius:4px;font-size:13px;\">${D8X_CHAIN}</code></div>"
+      }
+    },
+    {
+      "id": 100,
+      "type": "row",
+      "title": "Status",
+      "gridPos": {
+        "x": 0,
+        "y": 2,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 101,
+      "title": "Confirmed liquidations",
+      "description": "Liquidation transactions accepted on-chain in the selected time range. Counted from liquidator_liquidations_total{outcome=\"confirmed\"}.",
+      "type": "stat",
+      "gridPos": {
+        "x": 0,
+        "y": 3,
+        "w": 5,
+        "h": 4
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "green"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=\"confirmed\"}[$__range])) or vector(0)",
+          "legendFormat": "confirmed"
+        }
+      ]
+    },
+    {
+      "id": 102,
+      "title": "Failed",
+      "description": "Liquidations submitted but reverted on-chain in the selected time range. High values usually mean RPC/gas issues. liquidator_liquidations_total{outcome=\"failed\"}.",
+      "type": "stat",
+      "gridPos": {
+        "x": 5,
+        "y": 3,
+        "w": 5,
+        "h": 4
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=\"failed\"}[$__range])) or vector(0)",
+          "legendFormat": "failed"
+        }
+      ]
+    },
+    {
+      "id": 103,
+      "title": "Rejected",
+      "description": "Liquidation candidates the bot decided not to send (e.g. trader became margin-safe between detection and submit) in the selected time range. liquidator_liquidations_total{outcome=\"rejected\"}.",
+      "type": "stat",
+      "gridPos": {
+        "x": 10,
+        "y": 3,
+        "w": 5,
+        "h": 4
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=\"rejected\"}[$__range])) or vector(0)",
+          "legendFormat": "rejected"
+        }
+      ]
+    },
+    {
+      "id": 104,
+      "title": "Min Bot Balance",
+      "description": "Lowest configured min-balance threshold across the bot fleet (from liquidator_min_balance_eth).",
+      "type": "stat",
+      "gridPos": {
+        "x": 15,
+        "y": 3,
+        "w": 4,
+        "h": 4
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 6,
+          "unit": "ETH",
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.005
+              },
+              {
+                "color": "green",
+                "value": 0.02
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "min(liquidator_min_balance_eth{chain=\"${D8X_CHAIN}\"})",
+          "legendFormat": "min",
+          "instant": true,
+          "format": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 110,
+      "type": "row",
+      "title": "Throughput",
+      "gridPos": {
+        "x": 0,
+        "y": 29,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 111,
+      "title": "Liquidation rate, by outcome",
+      "description": "Per-second rate of liquidation attempts split by outcome over the last 5 minutes. Confirmed = on-chain success, Failed = tx reverted, Rejected = aborted before submit.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "stacking": {
+              "mode": "none"
+            },
+            "showPoints": "never",
+            "lineWidth": 2
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "confirmed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "rejected"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "sum",
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (outcome) (rate(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\"}[$__rate_interval]))",
+          "legendFormat": "{{outcome}}"
+        }
+      ]
+    },
+    {
+      "id": 112,
+      "title": "Top 10 symbols",
+      "description": "Symbols with the most liquidation events in the last hour, broken down by outcome. Tells you where the bot is doing real work.",
+      "type": "bargauge",
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "valueMode": "color",
+        "showUnfilled": true,
+        "minVizWidth": 0,
+        "minVizHeight": 16,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "topk(10, sum by (symbol) (increase(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=\"confirmed\"}[$__range])))",
+          "format": "time_series",
+          "instant": true,
+          "legendFormat": "{{symbol}}"
+        }
+      ]
+    },
+    {
+      "id": 120,
+      "type": "row",
+      "title": "Failures by Reason",
+      "gridPos": {
+        "x": 0,
+        "y": 42,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 121,
+      "title": "Failed + Rejected rate, by reason",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (outcome, reason) (rate(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=~\"failed|rejected\"}[$__rate_interval]))",
+          "legendFormat": "{{outcome}}/{{reason}}"
+        }
+      ]
+    },
+    {
+      "id": 122,
+      "title": "Top reasons (in time range)",
+      "type": "table",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "custom": {
+            "align": "left",
+            "filterable": true
+          }
+        }
+      },
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "topk(10, sum by (symbol, outcome, reason) (increase(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=~\"failed|rejected\"}[$__range])))",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "renameByName": {
+              "Value": "Count (1h)"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Count (1h)",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": 130,
+      "type": "row",
+      "title": "Bot Fleet",
+      "gridPos": {
+        "x": 0,
+        "y": 20,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 131,
+      "title": "Per-bot status",
+      "description": "One row per bot. Confirmed / Failed / Rejected / Funding failures counted over the selected time range; Idle for is time since last successful liquidation.",
+      "type": "table",
+      "gridPos": {
+        "x": 0,
+        "y": 21,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 4,
+          "noValue": "no data",
+          "custom": {
+            "align": "right",
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Balance (ETH)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ETH"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 0.005
+                    },
+                    {
+                      "color": "green",
+                      "value": 0.02
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Idle for (s)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 1800
+                    },
+                    {
+                      "color": "red",
+                      "value": 7200
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Address"
+            },
+            "properties": [
+              {
+                "id": "custom.minWidth",
+                "value": 380
+              },
+              {
+                "id": "custom.width",
+                "value": 380
+              },
+              {
+                "id": "custom.align",
+                "value": "left"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_bot_info{chain=\"${D8X_CHAIN}\", bot_addr!=\"\"}",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_bot_balance_eth{chain=\"${D8X_CHAIN}\"}",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "time() - liquidator_last_liquidation_timestamp_seconds{chain=\"${D8X_CHAIN}\"}",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (bot_idx) (increase(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=\"confirmed\"}[$__range]))",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "E",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (bot_idx) (increase(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=\"failed\"}[$__range]))",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "F",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (bot_idx) (increase(liquidator_liquidations_total{chain=\"${D8X_CHAIN}\", outcome=\"rejected\"}[$__range]))",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "G",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (bot_idx) (increase(liquidator_funding_failures_total{chain=\"${D8X_CHAIN}\"}[$__range]))",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "refId": "H",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (bot_idx) (increase(liquidator_gas_spent_wei_total{chain=\"${D8X_CHAIN}\"}[$__range])) / 1e18",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true,
+              "chain": true,
+              "Value #A": true
+            },
+            "indexByName": {
+              "bot_idx": 0,
+              "bot_addr": 1,
+              "Value #B": 2,
+              "Value #C": 3,
+              "Value #D": 4,
+              "Value #E": 5,
+              "Value #F": 6,
+              "Value #G": 7,
+              "Value #H": 8
+            },
+            "renameByName": {
+              "bot_idx": "Bot",
+              "bot_addr": "Address",
+              "Value #B": "Balance (ETH)",
+              "Value #C": "Idle for (s)",
+              "Value #D": "Confirmed",
+              "Value #E": "Failed",
+              "Value #F": "Rejected",
+              "Value #G": "Funding failures",
+              "Value #H": "Gas spent (ETH)"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 140,
+      "type": "row",
+      "title": "Funding",
+      "gridPos": {
+        "x": 0,
+        "y": 51,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 141,
+      "title": "Funding failures rate, by reason",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "showPoints": "never"
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (reason) (rate(liquidator_funding_failures_total{chain=\"${D8X_CHAIN}\"}[$__rate_interval]))",
+          "legendFormat": "{{reason}}"
+        }
+      ]
+    },
+    {
+      "id": 150,
+      "type": "row",
+      "title": "Liquidator activity",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 7,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 151,
+      "title": "Last pool check (sec ago)",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "never",
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "time() - max(liquidator_last_pool_check_seconds{chain=\"${D8X_CHAIN}\", status=\"ok\"})",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "Seconds since the last successful getLiquidatableAccountsInPool call. Value lags actual activity by up to one Prometheus scrape interval (currently 30s) -- a 'fresh' check can show as up to ~30s ago even when the commander is healthy. To reduce wobble, lower scrape_interval in prometheus.yaml."
+    },
+    {
+      "id": 152,
+      "title": "Pool checks (in time range)",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(liquidator_pool_checks_total{chain=\"${D8X_CHAIN}\"}[$__range]))",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "Total getLiquidatableAccountsInPool calls (ok + failed) in the selected time range."
+    },
+    {
+      "id": 153,
+      "title": "Currently liquidatable",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum(liquidator_last_pool_liquidatable_count{chain=\"${D8X_CHAIN}\"})",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "Trader count returned by the latest pool check. Drops back to 0 after liquidation attempts complete."
+    },
+    {
+      "id": 160,
+      "type": "row",
+      "title": "Config",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 11,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 161,
+      "title": "Gas limit",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 12
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_gas_limit{chain=\"${D8X_CHAIN}\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "From live.liquidatorConfig.json. Metric: liquidator_config_gas_limit"
+    },
+    {
+      "id": 163,
+      "title": "Gas multiplier",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 12
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "noValue": "0",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_gas_price_multiplier{chain=\"${D8X_CHAIN}\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "From live.liquidatorConfig.json. Metric: liquidator_config_gas_price_multiplier"
+    },
+    {
+      "id": 164,
+      "title": "Bots",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 12
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_bots{chain=\"${D8X_CHAIN}\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "From live.liquidatorConfig.json. Metric: liquidator_config_bots"
+    },
+    {
+      "id": 165,
+      "title": "Liquidate min (s)",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 12
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "unit": "s",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_liquidate_interval_seconds_min{chain=\"${D8X_CHAIN}\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "From live.liquidatorConfig.json. Metric: liquidator_config_liquidate_interval_seconds_min"
+    },
+    {
+      "id": 166,
+      "title": "Liquidate max (s)",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 12
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "unit": "s",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_liquidate_interval_seconds_max{chain=\"${D8X_CHAIN}\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "From live.liquidatorConfig.json. Metric: liquidator_config_liquidate_interval_seconds_max"
+    },
+    {
+      "id": 167,
+      "title": "Fetch prices min (s)",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 12
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "0",
+          "unit": "s",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_fetch_prices_interval_seconds_min{chain=\"${D8X_CHAIN}\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ],
+      "description": "From live.liquidatorConfig.json. Metric: liquidator_config_fetch_prices_interval_seconds_min"
+    },
+    {
+      "id": 105,
+      "title": "Treasury balance",
+      "description": "ETH balance of the treasury wallet (HD index 0). Funds the bot wallets when they run low. Metric: liquidator_treasury_balance_eth.",
+      "type": "stat",
+      "gridPos": {
+        "x": 19,
+        "y": 3,
+        "w": 5,
+        "h": 4
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 6,
+          "unit": "ETH",
+          "noValue": "no data",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.01
+              },
+              {
+                "color": "green",
+                "value": 0.05
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_treasury_balance_eth{chain=\"${D8X_CHAIN}\"}",
+          "legendFormat": "_",
+          "instant": true,
+          "format": "time_series"
+        }
+      ]
+    },
+    {
+      "id": 168,
+      "title": "Check min (s)",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 16
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "no data",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          },
+          "unit": "s"
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_check_interval_seconds_min{chain=\"${D8X_CHAIN}\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 169,
+      "title": "Check max (s)",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 16
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "no data",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          },
+          "unit": "s"
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_check_interval_seconds_max{chain=\"${D8X_CHAIN}\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 170,
+      "title": "Liquidatable batch",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 16
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "noValue": "no data",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_liquidatable_batch_size{chain=\"${D8X_CHAIN}\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 171,
+      "title": "Price move threshold",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 16
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "noValue": "no data",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          },
+          "unit": "percentunit"
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false,
+          "fields": ""
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "liquidator_config_price_move_pct_threshold{chain=\"${D8X_CHAIN}\"}",
+          "legendFormat": "_",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 180,
+      "type": "row",
+      "title": "Gas",
+      "gridPos": {
+        "x": 0,
+        "y": 60,
+        "w": 24,
+        "h": 1
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 181,
+      "title": "Gas spent (cumulative)",
+      "description": "Total native-token spent by the bot fleet on confirmed transactions, all-time. Sum of liquidator_gas_spent_wei_total / 1e18.",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 61
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 6,
+          "unit": "ETH",
+          "noValue": "0",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "orange"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum(liquidator_gas_spent_wei_total{chain=\"${D8X_CHAIN}\"}) / 1e18",
+          "instant": true,
+          "format": "time_series",
+          "legendFormat": "_"
+        }
+      ]
+    },
+    {
+      "id": 182,
+      "title": "Gas spent (last 24h)",
+      "description": "Native-token spent on confirmed transactions in the last 24 hours. increase(liquidator_gas_spent_wei_total[24h]) / 1e18.",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 61
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 6,
+          "unit": "ETH",
+          "noValue": "0",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "yellow"
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(liquidator_gas_spent_wei_total{chain=\"${D8X_CHAIN}\"}[24h])) / 1e18",
+          "instant": true,
+          "format": "time_series",
+          "legendFormat": "_"
+        }
+      ]
+    },
+    {
+      "id": 183,
+      "title": "Gas spent per bot (in time range)",
+      "description": "Native-token spent per bot wallet over the dashboard time range.",
+      "type": "bargauge",
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 61
+      },
+      "datasource": {
+        "uid": "d8x-prom",
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 6,
+          "unit": "ETH",
+          "color": {
+            "mode": "continuous-YlOr"
+          }
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "valueMode": "color",
+        "showUnfilled": true,
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "d8x-prom",
+            "type": "prometheus"
+          },
+          "expr": "sum by (bot_idx) (increase(liquidator_gas_spent_wei_total{chain=\"${D8X_CHAIN}\"}[$__range])) / 1e18",
+          "instant": true,
+          "format": "time_series",
+          "legendFormat": "bot {{bot_idx}}"
+        }
+      ]
+    }
+  ],
+  "timepicker": {
+    "hidden": false
+  }
+}

--- a/grafana/provisioning/dashboards/dashboards.yml
+++ b/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: d8x-liquidator
+    orgId: 1
+    folder: D8X
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      path: /etc/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/grafana/provisioning/datasources/prometheus.yml
+++ b/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: d8x-prom
+    url: http://prometheus:9090
+    access: proxy
+    isDefault: true
+    editable: false
+    jsonData:
+      httpMethod: POST
+      timeInterval: "30s"

--- a/prometheus_configs/prometheus.yaml
+++ b/prometheus_configs/prometheus.yaml
@@ -24,6 +24,11 @@ scrape_configs:
       - targets:
           - executor-base:9001
           - executor-base_sepolia:9001
+  - job_name: "liquidator-commander"
+    static_configs:
+      - targets:
+          - commander-base:9011
+          - commander-base_sepolia:9011
   - job_name: prometheus
     static_configs:
       - targets:

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -11,6 +11,7 @@ import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
 import { SDK_STATE_REPUBLISH_SECONDS, publishSDKState, refreshSDKStateTTL } from "../sdkState.js";
 import { loadWatchlist, PerpStates, publishWatchlist, serializePerpStates } from "../watchlist.js";
 import { createLogger } from "../logger.js";
+import { CommanderMetrics } from "./metrics.js";
 
 const log = createLogger("commander.distributor");
 
@@ -45,9 +46,12 @@ export default class Distributor {
 
   private config: LiquidatorConfig;
   private chainId: number;
+  private metrics: CommanderMetrics;
 
   constructor(config: LiquidatorConfig) {
     this.config = config;
+    this.metrics = new CommanderMetrics();
+    void this.metrics.start();
     this.redisSubClient = constructRedis("commanderSubClient");
     this.redisPubClient = constructRedis("commanderPubClient");
     const sdkConfig = PerpetualDataHandler.readSDKConfig(config.sdkConfig);
@@ -444,6 +448,7 @@ export default class Distributor {
         this.config.liquidatableBatchSize ?? 5,
       );
     } catch (e) {
+      this.metrics.observePoolCheck(poolId, "failed", 0);
       log.warn(
         { error: e instanceof Error ? e.message : String(e), poolId },
         "getLiquidatableAccountsInPool failed",
@@ -451,6 +456,7 @@ export default class Distributor {
       return;
     }
     const liquidatableCount = result.reduce((acc, r) => acc + r.traders.length, 0);
+    this.metrics.observePoolCheck(poolId, "ok", liquidatableCount);
     log.info(
       { poolId, perpsQueried: prices.size, perpsWithLiquidatable: result.length, liquidatableCount },
       "getLiquidatableAccountsInPool ok",

--- a/src/commander/metrics.ts
+++ b/src/commander/metrics.ts
@@ -1,0 +1,55 @@
+import * as promClient from "prom-client";
+import express from "express";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("commander.metrics");
+
+export class CommanderMetrics {
+  private readonly chain: string;
+
+  constructor(
+    chain: string = process.env.SDK_CONFIG ?? "unknown",
+    private port: number = parseInt(process.env.METRICS_PORT ?? "9011", 10),
+    private endpoint: string = "metrics",
+    private metricsList = {
+      lastPoolCheckSeconds: new promClient.Gauge({
+        name: "liquidator_last_pool_check_seconds",
+        help: "Unix timestamp of the last getLiquidatableAccountsInPool call, per pool and status.",
+        labelNames: ["chain", "pool_id", "status"] as const,
+      }),
+      poolChecksTotal: new promClient.Counter({
+        name: "liquidator_pool_checks_total",
+        help: "Cumulative count of getLiquidatableAccountsInPool calls, per pool and status.",
+        labelNames: ["chain", "pool_id", "status"] as const,
+      }),
+      lastPoolLiquidatableCount: new promClient.Gauge({
+        name: "liquidator_last_pool_liquidatable_count",
+        help: "Number of liquidatable traders returned by the last successful pool check.",
+        labelNames: ["chain", "pool_id"] as const,
+      }),
+    },
+  ) {
+    this.chain = chain;
+  }
+
+  public async start() {
+    const app = express();
+    app.get(`/${this.endpoint}`, async (_req: any, res: any) => {
+      res.set("Content-Type", promClient.register.contentType);
+      res.end(await promClient.register.metrics());
+    });
+    log.info({ port: this.port, endpoint: this.endpoint }, "starting commander metrics endpoint");
+    app.listen(this.port);
+  }
+
+  public observePoolCheck(poolId: number, status: "ok" | "failed", liquidatableCount: number) {
+    const labels = { chain: this.chain, pool_id: String(poolId), status };
+    this.metricsList.lastPoolCheckSeconds.set(labels, Math.floor(Date.now() / 1000));
+    this.metricsList.poolChecksTotal.inc(labels);
+    if (status === "ok") {
+      this.metricsList.lastPoolLiquidatableCount
+        .labels(this.chain, String(poolId))
+        .set(liquidatableCount);
+    }
+  }
+}

--- a/src/executor/liquidator.ts
+++ b/src/executor/liquidator.ts
@@ -85,7 +85,19 @@ export default class Liquidator {
       api: new LiquidatorTool(sdkConfig, pk),
       busy: false,
     }));
-    this.bots.forEach((bot, idx) => this.metrics.registerBot(idx, bot.api.getAddress()));
+    this.privateKey.forEach((pk, idx) => this.metrics.registerBot(idx, new Wallet(pk).address));
+    this.metrics.setConfigInfo({
+      gasLimit: this.config.gasLimit,
+      gasPriceMultiplier: this.config.gasPriceMultiplier,
+      bots: this.config.bots,
+      liquidateIntervalSecondsMin: this.config.liquidateIntervalSecondsMin,
+      liquidateIntervalSecondsMax: this.config.liquidateIntervalSecondsMax,
+      fetchPricesIntervalSecondsMin: this.config.fetchPricesIntervalSecondsMin,
+      checkIntervalSecondsMin: this.config.checkIntervalSecondsMin,
+      checkIntervalSecondsMax: this.config.checkIntervalSecondsMax,
+      liquidatableBatchSize: this.config.liquidatableBatchSize,
+      priceMovePctThreshold: this.config.priceMovePctThreshold,
+    });
 
     if (this.config.gasPriceMultiplier) {
       if (this.config.gasPriceMultiplier > 0) {
@@ -227,7 +239,7 @@ export default class Liquidator {
         },
         "txn rejected",
       );
-      this.metrics.incLiquidation(symbol, "rejected", categorizeRejectReason(e));
+      this.metrics.incLiquidation(botIdx, symbol, "rejected", categorizeRejectReason(e));
       this.bots[botIdx].busy = false;
       this.locked.delete(`${symbol}:${trader}`);
       return LiquidationStatus.Rejection;
@@ -258,7 +270,7 @@ export default class Liquidator {
         throw new Error("tx reverted on-chain (status=0)");
       }
       this.metrics.observeLastLiquidation(botIdx, receipt.from);
-      this.metrics.incLiquidation(symbol, "confirmed", "ok");
+      this.metrics.incLiquidation(botIdx, symbol, "confirmed", "ok");
       this.applyGasSpent(botIdx, receipt.from, receipt.gasUsed, receipt.gasPrice ?? 0n);
       log.info(
         {
@@ -275,7 +287,7 @@ export default class Liquidator {
       this.locked.delete(`${symbol}:${trader}`);
     } catch (e: any) {
       let error = e?.toString() || "";
-      this.metrics.incLiquidation(symbol, "failed", categorizeFailReason(e));
+      this.metrics.incLiquidation(botIdx, symbol, "failed", categorizeFailReason(e));
       log.error(
         {
           err: e,
@@ -419,6 +431,7 @@ export default class Liquidator {
     for (let addr of addressArray) {
       const botBalance = await provider.getBalance(addr);
       const treasuryBalance = await provider.getBalance(treasury.address);
+      this.metrics.setTreasuryBalance(treasury.address, Number(formatUnits(treasuryBalance, 18)));
       const botIdx = this.botIdxFromAddress(addr);
       if (botIdx >= 0) {
         this.botBalances.set(addr.toLowerCase(), botBalance);
@@ -478,9 +491,10 @@ export default class Liquidator {
 
   private applyGasSpent(botIdx: number, botAddr: string, gasUsed: bigint, gasPrice: bigint) {
     const key = botAddr.toLowerCase();
+    const cost = gasUsed * gasPrice;
+    this.metrics.incGasSpentWei(botIdx, cost);
     const cached = this.botBalances.get(key);
     if (cached === undefined) return;
-    const cost = gasUsed * gasPrice;
     const next = cost > cached ? 0n : cached - cost;
     this.botBalances.set(key, next);
     this.metrics.setBotBalance(botIdx, botAddr, Number(formatUnits(next, 18)));

--- a/src/executor/metrics.ts
+++ b/src/executor/metrics.ts
@@ -58,8 +58,8 @@ export class Metrics {
     private metricsList = {
       liquidationsTotal: new promClient.Counter({
         name: "liquidator_liquidations_total",
-        help: "Cumulative count of liquidation outcomes, by perpetual symbol and reason.",
-        labelNames: ["chain", "symbol", "outcome", "reason"] as const,
+        help: "Cumulative count of liquidation outcomes, by perpetual symbol, reason and worker wallet.",
+        labelNames: ["chain", "bot_idx", "symbol", "outcome", "reason"] as const,
       }),
       lastLiquidationTimestamp: new promClient.Gauge({
         name: "liquidator_last_liquidation_timestamp_seconds",
@@ -84,6 +84,66 @@ export class Metrics {
       minBalance: new promClient.Gauge({
         name: "liquidator_min_balance_eth",
         help: "Minimum native-token balance required for a bot to operate, computed as gasPrice * gasLimit * 5.",
+        labelNames: ["chain"] as const,
+      }),
+      treasuryBalance: new promClient.Gauge({
+        name: "liquidator_treasury_balance_eth",
+        help: "Native-token balance of the treasury wallet (HD index 0), in ETH.",
+        labelNames: ["chain", "treasury_addr"] as const,
+      }),
+      gasSpentWei: new promClient.Counter({
+        name: "liquidator_gas_spent_wei_total",
+        help: "Cumulative gas spent (wei) by each bot wallet on confirmed transactions. Daily = increase(...[1d]).",
+        labelNames: ["chain", "bot_idx"] as const,
+      }),
+      configGasLimit: new promClient.Gauge({
+        name: "liquidator_config_gas_limit",
+        help: "Configured gasLimit for liquidation transactions.",
+        labelNames: ["chain"] as const,
+      }),
+      configGasPriceMultiplier: new promClient.Gauge({
+        name: "liquidator_config_gas_price_multiplier",
+        help: "Multiplier applied to current gas price when sending transactions.",
+        labelNames: ["chain"] as const,
+      }),
+      configBots: new promClient.Gauge({
+        name: "liquidator_config_bots",
+        help: "Configured number of liquidator bot wallets.",
+        labelNames: ["chain"] as const,
+      }),
+      configLiquidateIntervalSecondsMin: new promClient.Gauge({
+        name: "liquidator_config_liquidate_interval_seconds_min",
+        help: "Minimum delay between liquidation attempts for the same trader.",
+        labelNames: ["chain"] as const,
+      }),
+      configLiquidateIntervalSecondsMax: new promClient.Gauge({
+        name: "liquidator_config_liquidate_interval_seconds_max",
+        help: "Maximum delay between liquidation attempts for the same trader.",
+        labelNames: ["chain"] as const,
+      }),
+      configFetchPricesIntervalSecondsMin: new promClient.Gauge({
+        name: "liquidator_config_fetch_prices_interval_seconds_min",
+        help: "Minimum interval between off-chain price fetches.",
+        labelNames: ["chain"] as const,
+      }),
+      configCheckIntervalSecondsMin: new promClient.Gauge({
+        name: "liquidator_config_check_interval_seconds_min",
+        help: "Minimum interval between commander pool checks.",
+        labelNames: ["chain"] as const,
+      }),
+      configCheckIntervalSecondsMax: new promClient.Gauge({
+        name: "liquidator_config_check_interval_seconds_max",
+        help: "Maximum interval between commander pool checks.",
+        labelNames: ["chain"] as const,
+      }),
+      configLiquidatableBatchSize: new promClient.Gauge({
+        name: "liquidator_config_liquidatable_batch_size",
+        help: "Max perps queried per Multicall in getLiquidatableAccountsInPool.",
+        labelNames: ["chain"] as const,
+      }),
+      configPriceMovePctThreshold: new promClient.Gauge({
+        name: "liquidator_config_price_move_pct_threshold",
+        help: "Spot price move (fraction) that triggers an early pool re-check.",
         labelNames: ["chain"] as const,
       }),
     },
@@ -112,9 +172,14 @@ export class Metrics {
     app.listen(port);
   }
 
-  public incLiquidation(symbol: string, outcome: LiquidationOutcome, reason: Reason, n: number = 1) {
+  public incLiquidation(botIdx: number, symbol: string, outcome: LiquidationOutcome, reason: Reason, n: number = 1) {
     if (n <= 0) return;
-    this.metricsList.liquidationsTotal.labels(this.chain, symbol, outcome, reason).inc(n);
+    this.metricsList.liquidationsTotal.labels(this.chain, String(botIdx), symbol, outcome, reason).inc(n);
+  }
+
+  public incGasSpentWei(botIdx: number, wei: bigint) {
+    if (wei <= 0n) return;
+    this.metricsList.gasSpentWei.labels(this.chain, String(botIdx)).inc(Number(wei));
   }
 
   public observeLastLiquidation(botIdx: number, botAddr: string, when: Date = new Date()) {
@@ -138,5 +203,37 @@ export class Metrics {
 
   public setMinBalance(eth: number) {
     this.metricsList.minBalance.labels(this.chain).set(eth);
+  }
+
+  public setTreasuryBalance(addr: string, eth: number) {
+    this.metricsList.treasuryBalance.labels(this.chain, addr.toLowerCase()).set(eth);
+  }
+
+  public setConfigInfo(cfg: {
+    gasLimit: number;
+    gasPriceMultiplier: number;
+    bots: number;
+    liquidateIntervalSecondsMin: number;
+    liquidateIntervalSecondsMax: number;
+    fetchPricesIntervalSecondsMin: number;
+    checkIntervalSecondsMin?: number;
+    checkIntervalSecondsMax?: number;
+    liquidatableBatchSize?: number;
+    priceMovePctThreshold?: number;
+  }) {
+    this.metricsList.configGasLimit.labels(this.chain).set(cfg.gasLimit);
+    this.metricsList.configGasPriceMultiplier.labels(this.chain).set(cfg.gasPriceMultiplier);
+    this.metricsList.configBots.labels(this.chain).set(cfg.bots);
+    this.metricsList.configLiquidateIntervalSecondsMin.labels(this.chain).set(cfg.liquidateIntervalSecondsMin);
+    this.metricsList.configLiquidateIntervalSecondsMax.labels(this.chain).set(cfg.liquidateIntervalSecondsMax);
+    this.metricsList.configFetchPricesIntervalSecondsMin.labels(this.chain).set(cfg.fetchPricesIntervalSecondsMin);
+    if (cfg.checkIntervalSecondsMin !== undefined)
+      this.metricsList.configCheckIntervalSecondsMin.labels(this.chain).set(cfg.checkIntervalSecondsMin);
+    if (cfg.checkIntervalSecondsMax !== undefined)
+      this.metricsList.configCheckIntervalSecondsMax.labels(this.chain).set(cfg.checkIntervalSecondsMax);
+    if (cfg.liquidatableBatchSize !== undefined)
+      this.metricsList.configLiquidatableBatchSize.labels(this.chain).set(cfg.liquidatableBatchSize);
+    if (cfg.priceMovePctThreshold !== undefined)
+      this.metricsList.configPriceMovePctThreshold.labels(this.chain).set(cfg.priceMovePctThreshold);
   }
 }


### PR DESCRIPTION
This PR does not change anything functional. it only collects metrics and attaches this tracker board:


<img width="1888" height="867" alt="Screenshot 2026-05-07 at 09 44 41" src="https://github.com/user-attachments/assets/8c5803cd-c9af-4dd4-89a5-441db70a9df1" />


- Right now everything is bound to 127.0.0.1 , so need to ssh tunnel to access it
the board tracks treasuring funds, gas consumption overtime, liquidations, errors, and current state
