### PR TITLE
refresh liquidator sdk on notmal and on demand

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@d8-x/d8x-node-sdk": "0.1.79",
+    "@d8-x/d8x-node-sdk": "0.1.80",
     "dotenv": "^16.0.3",
     "ethers": "^6.13.1",
     "express": "^4.19.2",

--- a/src/commander/distributor.ts
+++ b/src/commander/distributor.ts
@@ -367,6 +367,7 @@ export default class Distributor {
           return;
         }
       }
+      await this.publishState();
       // Only mark a successful reconcile (and reset the staleness clock) if
       // every desired NORMAL perp is actually being monitored. Otherwise
       // leave the success clock stale so the next tick retries the missing

--- a/src/executor/liquidator.ts
+++ b/src/executor/liquidator.ts
@@ -3,6 +3,7 @@ import { Network, Provider, TransactionResponse, Wallet, formatUnits } from "eth
 import { Redis } from "ioredis";
 import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
 import { initLiquidatorsFromMarketData, initMarketDataWithCache } from "../sdkInit.js";
+import { loadSDKState } from "../sdkState.js";
 import { BotStatus, LiquidateTraderMsg, LiquidatorConfig } from "../types.js";
 import { constructRedis, executeWithTimeout, sleep } from "../utils.js";
 import { loadWatchlist, parsePerpStates, watchlistChannel } from "../watchlist.js";
@@ -150,10 +151,19 @@ export default class Liquidator {
       for (let i = 0; i < 30 && this.bots.some((b) => b.busy); i++) {
         await sleep(100);
       }
-      await this.md.refreshSymbols(true);
       const provider = this.providers[this.lastUsedRpcIndex] ?? this.providers[0];
+      const cached = await loadSDKState(this.redisPubClient, {
+        chainId: this.chainId,
+        proxyAddr: this.sdkConfig.proxyAddr,
+      });
+      if (cached) {
+        await this.md.createProxyInstanceFromState(cached.state, provider);
+        log.info({ cacheAgeMs: cached.ageMs }, "executor: SDK state reloaded from commander cache");
+      } else {
+        await this.md.refreshSymbols(true);
+        log.info("executor: SDK state refreshed via RPC (no cache)");
+      }
       await initLiquidatorsFromMarketData(this.bots, this.md, provider);
-      log.info("executor: SDK static info refreshed");
     } catch (e) {
       log.warn({ err: e }, "executor: refreshSDK failed");
     } finally {

--- a/src/executor/liquidator.ts
+++ b/src/executor/liquidator.ts
@@ -3,7 +3,7 @@ import { Network, Provider, TransactionResponse, Wallet, formatUnits } from "eth
 import { Redis } from "ioredis";
 import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
 import { initLiquidatorsFromMarketData, initMarketDataWithCache } from "../sdkInit.js";
-import { loadSDKState } from "../sdkState.js";
+import { loadSDKState, sdkStateUpdatedChannel } from "../sdkState.js";
 import { BotStatus, LiquidateTraderMsg, LiquidatorConfig } from "../types.js";
 import { constructRedis, executeWithTimeout, sleep } from "../utils.js";
 import { loadWatchlist, parsePerpStates, watchlistChannel } from "../watchlist.js";
@@ -123,7 +123,7 @@ export default class Liquidator {
     // Subscribe to relayed events
     await this.redisSubClient.subscribe(
       "LiquidateTrader",
-      "PerpNormal",
+      sdkStateUpdatedChannel(this.chainId),
       watchlistChannel(this.chainId),
       (err, count) => {
         if (err) {
@@ -144,7 +144,7 @@ export default class Liquidator {
     log.info("initialized");
   }
 
-  private async refreshSDK(): Promise<void> {
+  private async refreshSDK(opts?: { forceRpc?: boolean }): Promise<void> {
     if (this.refreshingSDK) return;
     this.refreshingSDK = true;
     try {
@@ -152,16 +152,21 @@ export default class Liquidator {
         await sleep(100);
       }
       const provider = this.providers[this.lastUsedRpcIndex] ?? this.providers[0];
-      const cached = await loadSDKState(this.redisPubClient, {
-        chainId: this.chainId,
-        proxyAddr: this.sdkConfig.proxyAddr,
-      });
-      if (cached) {
-        await this.md.createProxyInstanceFromState(cached.state, provider);
-        log.info({ cacheAgeMs: cached.ageMs }, "executor: SDK state reloaded from commander cache");
-      } else {
+      if (opts?.forceRpc) {
         await this.md.refreshSymbols(true);
-        log.info("executor: SDK state refreshed via RPC (no cache)");
+        log.info("executor: SDK state refreshed via RPC (forced)");
+      } else {
+        const cached = await loadSDKState(this.redisPubClient, {
+          chainId: this.chainId,
+          proxyAddr: this.sdkConfig.proxyAddr,
+        });
+        if (cached) {
+          await this.md.createProxyInstanceFromState(cached.state, provider);
+          log.info({ cacheAgeMs: cached.ageMs }, "executor: SDK state reloaded from commander cache");
+        } else {
+          await this.md.refreshSymbols(true);
+          log.info("executor: SDK state refreshed via RPC (no cache)");
+        }
       }
       await initLiquidatorsFromMarketData(this.bots, this.md, provider);
     } catch (e) {
@@ -186,12 +191,17 @@ export default class Liquidator {
       });
 
       const watchlistCh = watchlistChannel(this.chainId);
+      const stateUpdCh = sdkStateUpdatedChannel(this.chainId);
       this.redisSubClient.on("message", async (channel, msg) => {
         if (channel === watchlistCh) {
           const states = parsePerpStates(msg);
           if (states) {
             this.allowedSymbols = new Set(Object.keys(states).filter((s) => states[s] === "NORMAL"));
           }
+          return;
+        }
+        if (channel === stateUpdCh) {
+          void this.refreshSDK();
           return;
         }
         switch (channel) {
@@ -213,10 +223,6 @@ export default class Liquidator {
                 success++;
               }
             }
-            break;
-          }
-          case "PerpNormal": {
-            void this.refreshSDK();
             break;
           }
         }
@@ -288,7 +294,7 @@ export default class Liquidator {
         }
       }
       if (typeof e?.message === "string" && e.message.includes("No perpetual found for symbol")) {
-        void this.refreshSDK();
+        void this.refreshSDK({ forceRpc: true });
       }
       this.bots[botIdx].busy = false;
       return LiquidationStatus.Rejection;

--- a/src/executor/liquidator.ts
+++ b/src/executor/liquidator.ts
@@ -141,6 +141,17 @@ export default class Liquidator {
       });
     }, 60 * 60 * 1_000).unref();
 
+    // Periodic SDK refresh as a safety net. The primary refresh paths are
+    // event-driven (sdk-state-updated channel) and lazy (force-RPC on
+    // "No perpetual found" rejections). This catches the rare edge case
+    // where neither fires — e.g. a Redis reconnect drops the subscription
+    // while no liquidations are attempted on newly-registered perps.
+    setInterval(() => {
+      this.refreshSDK().catch((err) => {
+        log.warn({ err }, "periodic refreshSDK failed");
+      });
+    }, 60 * 60 * 1_000).unref();
+
     log.info("initialized");
   }
 
@@ -153,7 +164,13 @@ export default class Liquidator {
       }
       const provider = this.providers[this.lastUsedRpcIndex] ?? this.providers[0];
       if (opts?.forceRpc) {
-        await this.md.refreshSymbols(true);
+        // Wrap with timeout: a hung refreshSymbols (e.g. unresponsive RPC) would
+        // leave refreshingSDK=true forever, blocking every liquidation.
+        await executeWithTimeout(
+          this.md.refreshSymbols(true),
+          30_000,
+          "refreshSymbols(true) timed out (forced RPC refresh)",
+        );
         log.info("executor: SDK state refreshed via RPC (forced)");
       } else {
         const cached = await loadSDKState(this.redisPubClient, {
@@ -164,7 +181,11 @@ export default class Liquidator {
           await this.md.createProxyInstanceFromState(cached.state, provider);
           log.info({ cacheAgeMs: cached.ageMs }, "executor: SDK state reloaded from commander cache");
         } else {
-          await this.md.refreshSymbols(true);
+          await executeWithTimeout(
+            this.md.refreshSymbols(true),
+            30_000,
+            "refreshSymbols(true) timed out (no-cache RPC refresh)",
+          );
           log.info("executor: SDK state refreshed via RPC (no cache)");
         }
       }
@@ -540,9 +561,7 @@ export default class Liquidator {
           if (botIdx >= 0) {
             this.metrics.incFundingFailure(botIdx, addr, "treasury_insufficient");
           }
-          throw new Error(
-            `treasury empty (${formatUnits(treasuryBalance)}); send funds to ${treasury.address}`,
-          );
+          throw new Error(`treasury empty (${formatUnits(treasuryBalance)}); send funds to ${treasury.address}`);
         }
         log.info(
           {

--- a/src/executor/liquidator.ts
+++ b/src/executor/liquidator.ts
@@ -4,7 +4,7 @@ import { Redis } from "ioredis";
 import { MultiUrlJsonRpcProvider } from "../multiUrlJsonRpcProvider.js";
 import { initLiquidatorsFromMarketData, initMarketDataWithCache } from "../sdkInit.js";
 import { BotStatus, LiquidateTraderMsg, LiquidatorConfig } from "../types.js";
-import { constructRedis, executeWithTimeout } from "../utils.js";
+import { constructRedis, executeWithTimeout, sleep } from "../utils.js";
 import { loadWatchlist, parsePerpStates, watchlistChannel } from "../watchlist.js";
 import { categorizeFailReason, categorizeRejectReason, Metrics } from "./metrics.js";
 import { createLogger } from "../logger.js";
@@ -25,6 +25,7 @@ export default class Liquidator {
   private bots: { api: LiquidatorTool; busy: boolean }[];
   private redisSubClient: Redis;
   private redisPubClient: Redis;
+  private md!: MarketData;
 
   // parameters
   private treasury: string;
@@ -35,6 +36,7 @@ export default class Liquidator {
   private gasPriceBuffer = 100n; // no buffer
   private lastUsedRpcIndex: number = 0;
   private fundingInProgress = false;
+  private refreshingSDK = false;
 
   // state
   private q: Set<string> = new Set();
@@ -103,13 +105,13 @@ export default class Liquidator {
    * An error is thrown if none of the providers works.
    */
   public async initialize() {
-    const md = new MarketData(this.sdkConfig);
-    const result = await initMarketDataWithCache(md, this.providers, this.redisPubClient);
+    this.md = new MarketData(this.sdkConfig);
+    const result = await initMarketDataWithCache(this.md, this.providers, this.redisPubClient);
     log.info(
       { cache: result.usedCache, cacheAgeMs: result.cacheAgeMs, providerIndex: result.providerIndex },
       "executor MarketData initialized",
     );
-    await initLiquidatorsFromMarketData(this.bots, md, this.providers[result.providerIndex]);
+    await initLiquidatorsFromMarketData(this.bots, this.md, this.providers[result.providerIndex]);
 
     const initial = await loadWatchlist(this.redisPubClient, this.chainId);
     if (initial !== null) {
@@ -118,12 +120,17 @@ export default class Liquidator {
     }
 
     // Subscribe to relayed events
-    await this.redisSubClient.subscribe("LiquidateTrader", watchlistChannel(this.chainId), (err, count) => {
-      if (err) {
-        log.error({ err }, "redis subscription failed");
-        process.exit(1);
-      }
-    });
+    await this.redisSubClient.subscribe(
+      "LiquidateTrader",
+      "PerpNormal",
+      watchlistChannel(this.chainId),
+      (err, count) => {
+        if (err) {
+          log.error({ err }, "redis subscription failed");
+          process.exit(1);
+        }
+      },
+    );
 
     // Periodic safety-net top-up; complements the rejection-driven path.
     setInterval(() => {
@@ -134,6 +141,24 @@ export default class Liquidator {
     }, 60 * 60 * 1_000).unref();
 
     log.info("initialized");
+  }
+
+  private async refreshSDK(): Promise<void> {
+    if (this.refreshingSDK) return;
+    this.refreshingSDK = true;
+    try {
+      for (let i = 0; i < 30 && this.bots.some((b) => b.busy); i++) {
+        await sleep(100);
+      }
+      await this.md.refreshSymbols(true);
+      const provider = this.providers[this.lastUsedRpcIndex] ?? this.providers[0];
+      await initLiquidatorsFromMarketData(this.bots, this.md, provider);
+      log.info("executor: SDK static info refreshed");
+    } catch (e) {
+      log.warn({ err: e }, "executor: refreshSDK failed");
+    } finally {
+      this.refreshingSDK = false;
+    }
   }
 
   /**
@@ -180,6 +205,10 @@ export default class Liquidator {
             }
             break;
           }
+          case "PerpNormal": {
+            void this.refreshSDK();
+            break;
+          }
         }
       });
     });
@@ -187,7 +216,7 @@ export default class Liquidator {
 
   private async liquidateTraderByBot(botIdx: number, symbol: string, trader: string) {
     trader = trader.toLowerCase();
-    if (this.bots[botIdx].busy || this.locked.has(`${symbol}:${trader}`)) {
+    if (this.refreshingSDK || this.bots[botIdx].busy || this.locked.has(`${symbol}:${trader}`)) {
       return LiquidationStatus.NoOp;
     }
     if (this.allowedSymbols === null || !this.allowedSymbols.has(symbol)) {
@@ -247,6 +276,9 @@ export default class Liquidator {
         } catch (fundErr: any) {
           log.error({ err: fundErr, bot }, "failed to fund bot");
         }
+      }
+      if (typeof e?.message === "string" && e.message.includes("No perpetual found for symbol")) {
+        void this.refreshSDK();
       }
       this.bots[botIdx].busy = false;
       return LiquidationStatus.Rejection;

--- a/src/sdkState.ts
+++ b/src/sdkState.ts
@@ -8,6 +8,10 @@ export function sdkStateKey(chainId: number): string {
   return `sdk-state:${chainId}`;
 }
 
+export function sdkStateUpdatedChannel(chainId: number): string {
+  return `sdk-state-updated:${chainId}`;
+}
+
 interface CachedSDKState {
   sdkVersion: string;
   publishedAt: number;
@@ -22,6 +26,7 @@ export interface LoadedSDKState {
 export async function publishSDKState(redis: Redis, chainId: number, state: SDKState): Promise<void> {
   const payload: CachedSDKState = { sdkVersion: D8X_SDK_VERSION, publishedAt: Date.now(), state };
   await redis.set(sdkStateKey(chainId), JSON.stringify(payload), "EX", SDK_STATE_TTL_SECONDS);
+  await redis.publish(sdkStateUpdatedChannel(chainId), "");
 }
 
 export async function refreshSDKStateTTL(redis: Redis, chainId: number): Promise<boolean> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,10 +14,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@d8-x/d8x-node-sdk@0.1.79":
-  version "0.1.79"
-  resolved "https://npm.pkg.github.com/download/@d8-x/d8x-node-sdk/0.1.79/df0f03986e9916e681e8d1ac6f6c34ed3f504abc#df0f03986e9916e681e8d1ac6f6c34ed3f504abc"
-  integrity sha512-BoXqJNcGYdDJWDtf+galcE0XchwLy5cmRzxnPsWyiD4608F6rm6H94lzm2URaIlP46Ritp+1OXCaP8uAZHw8EQ==
+"@d8-x/d8x-node-sdk@0.1.80":
+  version "0.1.80"
+  resolved "https://npm.pkg.github.com/download/@d8-x/d8x-node-sdk/0.1.80/b403b5f35612ed37be0557a56271798c81b21703#b403b5f35612ed37be0557a56271798c81b21703"
+  integrity sha512-pAzcxwwiXUF6HqTh2hfFxlSufmQiR8J4cf6DZVs/HOvhSLzChtP0unsz97Ne6JHO8wU2+XhKjye6u0NZQSFLog==
   dependencies:
     "@d8-x/d8x-price-wasm" "^1.0.33"
     "@typechain/ethers-v6" "^0.5.1"


### PR DESCRIPTION
there exists a staleness gap window between the commander and executor known perps

the commander now publishes a sdk-state-updated:<chainId> Redis signal after each successful state write, the executor subscribes to that and reloads fro m cache (zero RPC), and the catch block path forces a direct RPC refresh when it encounters a perp the cache doesn't yet know about.