### PR TITLE
fix build: remove duplicate incLiquidation call

### DIFF
--- a/src/executor/liquidator.ts
+++ b/src/executor/liquidator.ts
@@ -318,7 +318,6 @@ export default class Liquidator {
       );
       this.metrics.incLiquidation(botIdx, symbol, "rejected", categorizeRejectReason(e));
       this.bots[botIdx].busy = false;
-      this.metrics.incLiquidation(symbol, "rejected", categorizeRejectReason(e));
       this.locked.delete(`${symbol}:${trader}`);
       if (e?.code === "INSUFFICIENT_FUNDS" || reason.includes("insufficient funds for intrinsic transaction cost")) {
         const bot = this.bots[botIdx].api.getAddress();


### PR DESCRIPTION
## Summary

- Removes a stale 3-arg \`incLiquidation\` call at \`src/executor/liquidator.ts:321\` that was left behind by the metrics refactor in #37
- Restores the image-build pipeline — every CI run since 5/11 has failed with \`TS2554: Expected 4-5 arguments, but got 3\`, so \`:dev\` and \`:main\` on GHCR have been frozen at the 5/10 image (no merged PRs since have actually shipped)

## What changed

Single-line deletion. The correct 4-arg call already exists at line 319; line 321 was a leftover from before the signature change and was both double-counting rejected liquidations and breaking typecheck.

\`\`\`diff
       this.metrics.incLiquidation(botIdx, symbol, "rejected", categorizeRejectReason(e));
       this.bots[botIdx].busy = false;
-      this.metrics.incLiquidation(symbol, "rejected", categorizeRejectReason(e));
       this.locked.delete(\`\${symbol}:\${trader}\`);
\`\`\`

## Test plan

- [x] \`npx tsc --noEmit\` passes locally
- [x] CI image build runs green
- [x] \`:dev\` digest on GHCR advances past 5/10 build