### PR TITLE
ci: yarn build on push, docker image build on PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,41 @@
-name: Build Liquidator Images (no push)
+name: Build
 
 on:
   push:
     branches-ignore: [main, dev, DEV]
+  pull_request:
 
 permissions:
   contents: read
   packages: read
 
 jobs:
-  build:
+  yarn-build:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Configure npm auth for @d8-x
+        run: cp dotnpmrcexample .npmrc
+
+      - name: Install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+  image-build:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build Liquidator Images (no push)
+
+on:
+  push:
+    branches-ignore: [main, dev, DEV]
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - name: sentinel
+            dockerfile: ./src/sentinel/Dockerfile
+          - name: executor
+            dockerfile: ./src/executor/Dockerfile
+          - name: commander
+            dockerfile: ./src/commander/Dockerfile
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build (${{ matrix.service.name }})
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.service.dockerfile }}
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          secrets: |
+            npm_token=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build.yml`
- `yarn-build` job runs on `push` to any branch except `main`/`dev`/`DEV`
- `image-build` job (docker build, no push to GHCR) runs on `pull_request`

## Test plan
- [x] Push a commit to a feature branch and confirm only `yarn-build` runs
- [ ] Open a PR against `dev` and confirm only `image-build` runs (all 3 services)
- [ ] Confirm pushes to `main`/`dev`/`DEV` do not trigger this workflow (existing `images.yml` still handles those)

🤖 Generated with [Claude Code](https://claude.com/claude-code)